### PR TITLE
fix(balance): stop freezing mid-day provider readings as waypoints

### DIFF
--- a/app/models/account/current_balance_manager.rb
+++ b/app/models/account/current_balance_manager.rb
@@ -93,18 +93,12 @@ class Account::CurrentBalanceManager
     # This is NOT a user-facing feature, and is primarily used in "processors" while syncing
     # linked account data (e.g. via Plaid).
     #
-    # There is exactly one `current_anchor` per linked account, and it is written AFTER
-    # that sync's transactions have been imported (see each processor's `process`). That
-    # ordering is what makes this safe: by the time we're about to overwrite a standing
-    # anchor with today's reading, the ledger for the gap between them is complete, so we
-    # can judge it right now instead of waiting for a later sync.
+    # Processors write the anchor AFTER importing the sync's transactions, so the ledger for
+    # the gap since the standing anchor is complete and we can judge it now:
     #
-    #   * the imported ledger explains the move to today's reading -> the old anchor
-    #     carries nothing the transactions don't already carry, so it just moves forward
-    #     in place (date AND amount) exactly like a same-day update
-    #   * it doesn't -> the provider knew something the ledger doesn't, so the old anchor
-    #     is preserved as a reconciliation waypoint (#1492, #1484) and a fresh anchor is
-    #     created for today
+    #   * the ledger explains the move -> the old anchor just moves forward in place
+    #   * it doesn't -> the provider knew something the ledger doesn't, so the old anchor is
+    #     kept as a reconciliation waypoint (#1492, #1484) and a fresh anchor created for today
     def set_current_balance_for_linked_account(balance)
       changes_made = false
 
@@ -129,33 +123,36 @@ class Account::CurrentBalanceManager
       Result.new(success?: true, changes_made?: changes_made, error: nil)
     end
 
-    # Deterministic even if legacy data (from a version that kept two anchors around)
-    # still carries more than one row: the newest one is always the live anchor.
+    # Legacy data can still carry more than one anchor row, and the query has no ORDER BY,
+    # so pick the newest deterministically. Ids are random UUIDs: a last-resort tiebreak only.
     def current_anchor_valuation
       @current_anchor_valuation ||=
-        account.valuations.current_anchor.includes(:entry).max_by { |v| v.entry.date }
+        account.valuations.current_anchor.includes(:entry).max_by { |v| [ v.entry.date, v.entry.created_at, v.entry.id ] }
     end
 
     # True when imported transactions and trades account for the entire move between the
     # standing anchor and the reading we're about to write.
     #
     # Sign convention is Balance::ForwardCalculator#signed_entry_flows: a positive entry
-    # amount decreases an asset and increases a liability, so
-    #   expected = older + (asset? ? -net : net)
-    # One sum covers any gap length, because that recurrence is additive across days.
+    # amount decreases an asset and increases a liability. One sum covers any gap length.
     #
-    # Both endpoints are inclusive. The lower one is load-bearing: the reading is mid-day,
-    # so entries dated on the older anchor's own date posted after it was taken. The upper
-    # one is right because it is the reading being written now, which by construction is
-    # the last one for today.
+    # The window is inclusive at both ends. The lower end matters because readings are taken
+    # mid-day, so entries dated on the anchor's own date can post after it was taken. On that
+    # date only, entries that predate the anchor's last write are skipped: the provider could
+    # already see them, so after an in-place move they are inside the stored amount and
+    # counting them again would make an explained move look unexplained. `updated_at` is the
+    # watermark (saved exactly when amount and/or date change) and `>` excludes entries
+    # imported in the same sync cycle as the anchor write, which share its timestamp.
     #
-    # Restricted to :cash accounts. For :investment the reported total moves with market
-    # prices and trades only shift cash <-> holdings, so the identity means nothing.
-    # :non_cash accounts are left out until someone measures a real feed: Property and
-    # friends are valuation-driven, and Loan is entry-driven but has no linked provider
-    # whose readings we have checked.
+    # Restricted to :cash accounts: an :investment total moves with market prices, and
+    # :non_cash accounts are valuation-driven, so the identity means nothing for either.
     def ledger_explains?(older_entry, new_balance)
       return false unless account.balance_type == :cash
+
+      # The identity below adds account-currency flows to the anchor's own amount, so an anchor
+      # written before a provider corrected the account's currency mixes units. Moving it forward
+      # would not repair that: `update_current_anchor` only ever rewrites amount and date.
+      return false unless older_entry.currency == account.currency
 
       # Same set the balance calculators see (Balance::SyncCache#converted_entries and
       # #get_entries): transactions and trades only, pending and split parents out,
@@ -165,6 +162,8 @@ class Account::CurrentBalanceManager
         .excluding_split_parents
         .where(date: older_entry.date..Date.current)
         .where.not(entryable_type: "Valuation")
+        .where("entries.date > :anchor_date OR entries.created_at > :anchor_written_at",
+               anchor_date: older_entry.date, anchor_written_at: older_entry.updated_at)
         .pluck(:currency, :amount)
 
       # A plain sum would silently add EUR to USD; bail rather than guess an FX rate.

--- a/app/models/account/current_balance_manager.rb
+++ b/app/models/account/current_balance_manager.rb
@@ -91,21 +91,34 @@ class Account::CurrentBalanceManager
 
     # Linked accounts manage "current balance" via the special `current_anchor` valuation.
     # This is NOT a user-facing feature, and is primarily used in "processors" while syncing
-    # linked account data (e.g. via Plaid)
+    # linked account data (e.g. via Plaid).
     #
-    # Before overwriting a stale (previous-day) current_anchor, we convert it to a
-    # reconciliation valuation. This preserves the API-reported balance as a historical
-    # waypoint that the ReverseCalculator uses for more accurate balance history.
+    # There is exactly one `current_anchor` per linked account, and it is written AFTER
+    # that sync's transactions have been imported (see each processor's `process`). That
+    # ordering is what makes this safe: by the time we're about to overwrite a standing
+    # anchor with today's reading, the ledger for the gap between them is complete, so we
+    # can judge it right now instead of waiting for a later sync.
+    #
+    #   * the imported ledger explains the move to today's reading -> the old anchor
+    #     carries nothing the transactions don't already carry, so it just moves forward
+    #     in place (date AND amount) exactly like a same-day update
+    #   * it doesn't -> the provider knew something the ledger doesn't, so the old anchor
+    #     is preserved as a reconciliation waypoint (#1492, #1484) and a fresh anchor is
+    #     created for today
     def set_current_balance_for_linked_account(balance)
       changes_made = false
 
       ActiveRecord::Base.transaction do
-        # If an anchor exists from a previous day, preserve it as a reconciliation
-        # before replacing it with today's fresh anchor.
-        preserve_anchor_as_reconciliation_if_stale if current_anchor_valuation
+        anchor = current_anchor_valuation
 
-        # Re-check: the memoized value was cleared if the anchor was converted
-        if current_anchor_valuation
+        if anchor && anchor.entry.date < Date.current && !ledger_explains?(anchor.entry, balance)
+          anchor.update!(kind: "reconciliation")
+          anchor.entry.update!(name: Valuation.build_reconciliation_name(account.accountable_type))
+          Rails.logger.info("[AnchorRotation] Converted current_anchor to reconciliation for account #{account.id}, date=#{anchor.entry.date}, entry_id=#{anchor.entry.id}")
+          anchor = nil
+        end
+
+        if anchor
           changes_made = update_current_anchor(balance)
         else
           create_current_anchor(balance)
@@ -116,27 +129,51 @@ class Account::CurrentBalanceManager
       Result.new(success?: true, changes_made?: changes_made, error: nil)
     end
 
+    # Deterministic even if legacy data (from a version that kept two anchors around)
+    # still carries more than one row: the newest one is always the live anchor.
     def current_anchor_valuation
-      @current_anchor_valuation ||= account.valuations.current_anchor.includes(:entry).first
+      @current_anchor_valuation ||=
+        account.valuations.current_anchor.includes(:entry).max_by { |v| v.entry.date }
     end
 
-    # If the existing current_anchor is from a previous day, convert it to a
-    # reconciliation before overwriting. This accumulates a chain of API-reported
-    # balance waypoints over time without creating extra entries per sync.
+    # True when imported transactions and trades account for the entire move between the
+    # standing anchor and the reading we're about to write.
     #
-    # Same-day updates are left in place (no extra reconciliations on repeated syncs).
-    def preserve_anchor_as_reconciliation_if_stale
-      entry = current_anchor_valuation.entry
-      return if entry.date == Date.current # Same-day update — nothing to preserve
+    # Sign convention is Balance::ForwardCalculator#signed_entry_flows: a positive entry
+    # amount decreases an asset and increases a liability, so
+    #   expected = older + (asset? ? -net : net)
+    # One sum covers any gap length, because that recurrence is additive across days.
+    #
+    # Both endpoints are inclusive. The lower one is load-bearing: the reading is mid-day,
+    # so entries dated on the older anchor's own date posted after it was taken. The upper
+    # one is right because it is the reading being written now, which by construction is
+    # the last one for today.
+    #
+    # Restricted to :cash accounts. For :investment the reported total moves with market
+    # prices and trades only shift cash <-> holdings, so the identity means nothing.
+    # :non_cash accounts are left out until someone measures a real feed: Property and
+    # friends are valuation-driven, and Loan is entry-driven but has no linked provider
+    # whose readings we have checked.
+    def ledger_explains?(older_entry, new_balance)
+      return false unless account.balance_type == :cash
 
-      current_anchor_valuation.update!(kind: "reconciliation")
-      entry.update!(name: Valuation.build_reconciliation_name(account.accountable_type))
-      Rails.logger.info("[AnchorRotation] Converted current_anchor to reconciliation for account #{account.id}, date=#{entry.date}, entry_id=#{entry.id}")
+      # Same set the balance calculators see (Balance::SyncCache#converted_entries and
+      # #get_entries): transactions and trades only, pending and split parents out,
+      # `excluded` entries still counted.
+      flows = account.entries
+        .excluding_pending
+        .excluding_split_parents
+        .where(date: older_entry.date..Date.current)
+        .where.not(entryable_type: "Valuation")
+        .pluck(:currency, :amount)
 
-      # Clear memoized value so the next check creates a fresh current_anchor.
-      # The chained scope (.current_anchor.first) always issues a fresh SQL query,
-      # so we don't need to reload the full association.
-      @current_anchor_valuation = nil
+      # A plain sum would silently add EUR to USD; bail rather than guess an FX rate.
+      return false unless flows.all? { |currency, _| currency == account.currency }
+
+      net = flows.sum { |_, amount| amount }
+      expected = older_entry.amount + (account.asset? ? -net : net)
+
+      (expected - new_balance).abs <= BigDecimal("0.01")
     end
 
     def create_current_anchor(balance)

--- a/app/models/coinstats_account/processor.rb
+++ b/app/models/coinstats_account/processor.rb
@@ -27,8 +27,10 @@ class CoinstatsAccount::Processor
       report_exception(e, "holdings")
     end
 
+    anchor_balance = nil
+
     begin
-      process_account!
+      anchor_balance = process_account!
     rescue StandardError => e
       Rails.logger.error "CoinstatsAccount::Processor - Failed to process account #{coinstats_account.id}: #{e.message}"
       Rails.logger.error "Backtrace: #{e.backtrace.join("\n")}"
@@ -37,6 +39,10 @@ class CoinstatsAccount::Processor
     end
 
     process_transactions
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    coinstats_account.current_account.set_current_balance(anchor_balance) if anchor_balance
   end
 
   private
@@ -58,7 +64,8 @@ class CoinstatsAccount::Processor
         currency: currency
       )
 
-      account.set_current_balance(balance)
+      # Returned to `process`, which anchors it once transactions are in.
+      balance
     end
 
     # Delegates transaction processing to the specialized processor.

--- a/app/models/coinstats_account/processor.rb
+++ b/app/models/coinstats_account/processor.rb
@@ -38,11 +38,13 @@ class CoinstatsAccount::Processor
       raise
     end
 
-    process_transactions
+    transactions_ok = process_transactions
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
-    coinstats_account.current_account.set_current_balance(anchor_balance) if anchor_balance
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
+    # A failed import leaves the ledger incomplete, so skip anchoring and let the next
+    # successful sync judge the wider gap.
+    coinstats_account.current_account.set_current_balance(anchor_balance) if anchor_balance && transactions_ok
   end
 
   private
@@ -69,10 +71,12 @@ class CoinstatsAccount::Processor
     end
 
     # Delegates transaction processing to the specialized processor.
+    # Returns whether every transaction was imported, which gates the anchor in `process`.
     def process_transactions
-      CoinstatsAccount::Transactions::Processor.new(coinstats_account).process
+      CoinstatsAccount::Transactions::Processor.new(coinstats_account).process[:success]
     rescue StandardError => e
       report_exception(e, "transactions")
+      false
     end
 
     # Reports errors to Sentry with context tags.

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -27,15 +27,19 @@ class EnableBankingAccount::Processor
       raise
     end
 
-    process_transactions
+    transactions_ok = process_transactions
 
-    if anchor_balance
-      begin
-        result = enable_banking_account.current_account.set_current_balance(anchor_balance)
-        raise ProcessingError, "Failed to set current balance: #{result.error}" unless result.success?
-      rescue StandardError => e
-        report_exception(e, "account")
-        raise
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
+    # A failed import leaves the ledger incomplete, so skip anchoring and let the next
+    # successful sync judge the wider gap.
+    if anchor_balance && transactions_ok
+      result = enable_banking_account.current_account.set_current_balance(anchor_balance)
+
+      unless result.success?
+        error = ProcessingError.new("Failed to set current balance: #{result.error}")
+        report_exception(error, "account")
+        raise error
       end
     end
   end
@@ -96,10 +100,9 @@ class EnableBankingAccount::Processor
         end
       end
 
-      # Anchor the reported balance AFTER importing, so the previous reading can be judged
-      # against a complete ledger. This enables Balance::ReverseCalculator, which works
-      # backward from the bank-reported balance — eliminating spurious cash adjustment
-      # spikes. Returned to `process`, which anchors it once transactions are in.
+      # Returned to `process`, which anchors it once transactions are in. That anchor drives
+      # Balance::ReverseCalculator, which works backward from the bank-reported balance -
+      # eliminating spurious cash adjustment spikes.
       balance unless skip_balance_update
     end
 
@@ -172,10 +175,12 @@ class EnableBankingAccount::Processor
       )
     end
 
+    # Returns whether every transaction was imported, which gates the anchor in `process`.
     def process_transactions
-      EnableBankingAccount::Transactions::Processor.new(enable_banking_account).process
+      EnableBankingAccount::Transactions::Processor.new(enable_banking_account).process[:success]
     rescue => e
       report_exception(e, "transactions")
+      false
     end
 
     def report_exception(error, context)

--- a/app/models/enable_banking_account/processor.rb
+++ b/app/models/enable_banking_account/processor.rb
@@ -16,8 +16,10 @@ class EnableBankingAccount::Processor
 
     Rails.logger.info "EnableBankingAccount::Processor - Processing enable_banking_account #{enable_banking_account.id} (uid #{enable_banking_account.uid})"
 
+    anchor_balance = nil
+
     begin
-      process_account!
+      anchor_balance = process_account!
     rescue StandardError => e
       Rails.logger.error "EnableBankingAccount::Processor - Failed to process account #{enable_banking_account.id}: #{e.message}"
       Rails.logger.error "Backtrace: #{e.backtrace.join("\n")}"
@@ -26,6 +28,16 @@ class EnableBankingAccount::Processor
     end
 
     process_transactions
+
+    if anchor_balance
+      begin
+        result = enable_banking_account.current_account.set_current_balance(anchor_balance)
+        raise ProcessingError, "Failed to set current balance: #{result.error}" unless result.success?
+      rescue StandardError => e
+        report_exception(e, "account")
+        raise
+      end
+    end
   end
 
   private
@@ -81,17 +93,14 @@ class EnableBankingAccount::Processor
           account.update!(currency: currency)
         else
           account.update!(currency: currency, cash_balance: balance)
-
-          # Use set_current_balance to create a current_anchor valuation entry.
-          # This enables Balance::ReverseCalculator, which works backward from the
-          # bank-reported balance — eliminating spurious cash adjustment spikes.
-          result = account.set_current_balance(balance)
-          raise ProcessingError, "Failed to set current balance: #{result.error}" unless result.success?
         end
       end
 
-      # TODO: pass explicit window_start_date to sync_later to avoid full history recalculation on every sync
-      # Currently relies on set_current_balance's implicit sync trigger; window params would require refactor
+      # Anchor the reported balance AFTER importing, so the previous reading can be judged
+      # against a complete ledger. This enables Balance::ReverseCalculator, which works
+      # backward from the bank-reported balance — eliminating spurious cash adjustment
+      # spikes. Returned to `process`, which anchors it once transactions are in.
+      balance unless skip_balance_update
     end
 
     # Interprets the reported credit card balance based on the

--- a/app/models/ibkr_account/processor.rb
+++ b/app/models/ibkr_account/processor.rb
@@ -12,8 +12,8 @@ class IbkrAccount::Processor
     IbkrAccount::HoldingsProcessor.new(ibkr_account).process
     IbkrAccount::ActivitiesProcessor.new(ibkr_account).process
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(total_balance)
 
     repair_default_opening_anchor!

--- a/app/models/ibkr_account/processor.rb
+++ b/app/models/ibkr_account/processor.rb
@@ -8,9 +8,14 @@ class IbkrAccount::Processor
   def process
     return unless account.present?
 
-    update_account_balance!
+    total_balance = update_account_balance!
     IbkrAccount::HoldingsProcessor.new(ibkr_account).process
     IbkrAccount::ActivitiesProcessor.new(ibkr_account).process
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(total_balance)
+
     repair_default_opening_anchor!
 
     account.broadcast_sync_complete
@@ -32,7 +37,9 @@ class IbkrAccount::Processor
         currency: ibkr_account.currency
       )
       account.save!
-      account.set_current_balance(total_balance)
+
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      total_balance
     end
 
     def repair_default_opening_anchor!

--- a/app/models/indexa_capital_account/processor.rb
+++ b/app/models/indexa_capital_account/processor.rb
@@ -15,8 +15,7 @@ class IndexaCapitalAccount::Processor
 
     Rails.logger.info "IndexaCapitalAccount::Processor - Processing account #{indexa_capital_account.id} -> Sure account #{account.id}"
 
-    # Update account balance FIRST (before processing transactions/holdings/activities)
-    update_account_balance(account)
+    anchor_balance = update_account_balance(account)
 
     # Process holdings
     holdings_count = indexa_capital_account.raw_holdings_payload&.size || 0
@@ -39,6 +38,10 @@ class IndexaCapitalAccount::Processor
     else
       Rails.logger.warn "IndexaCapitalAccount::Processor - No activities payload to process"
     end
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed
     account.broadcast_sync_complete
@@ -64,9 +67,8 @@ class IndexaCapitalAccount::Processor
       )
       account.save!
 
-      # Create or update the current balance anchor valuation for linked accounts
-      # This is critical for reverse sync to work correctly
-      account.set_current_balance(total_balance)
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      total_balance
     end
 
     def calculate_total_balance

--- a/app/models/indexa_capital_account/processor.rb
+++ b/app/models/indexa_capital_account/processor.rb
@@ -39,8 +39,8 @@ class IndexaCapitalAccount::Processor
       Rails.logger.warn "IndexaCapitalAccount::Processor - No activities payload to process"
     end
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed

--- a/app/models/plaid_account/processor.rb
+++ b/app/models/plaid_account/processor.rb
@@ -12,10 +12,14 @@ class PlaidAccount::Processor
   # Processing the account is the first step and if it fails, we halt the entire processor
   # Each subsequent step can fail independently, but we continue processing the rest of the steps
   def process
-    process_account!
+    account = process_account!
     process_transactions
     process_investments
     process_liabilities
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account&.set_current_balance(balance_calculator.balance)
   end
 
   private
@@ -88,12 +92,14 @@ class PlaidAccount::Processor
           )
         end
 
-        # Create or update the current balance anchor valuation for event-sourced ledger
+        # Returned to `process`, which creates or updates the current balance anchor
+        # valuation once transactions are in.
+        #
         # Note: This is a partial implementation. In the future, we'll introduce HoldingValuation
         # to properly track the holdings vs. cash breakdown, but for now we're only tracking
         # the total balance in the current anchor. The cash_balance field on the account model
         # is still being used for the breakdown.
-        account.set_current_balance(balance_calculator.balance)
+        account
       end
     end
 

--- a/app/models/plaid_account/processor.rb
+++ b/app/models/plaid_account/processor.rb
@@ -13,13 +13,16 @@ class PlaidAccount::Processor
   # Each subsequent step can fail independently, but we continue processing the rest of the steps
   def process
     account = process_account!
-    process_transactions
-    process_investments
+    transactions_ok = process_transactions
+    investments_ok = process_investments
     process_liabilities
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
-    account&.set_current_balance(balance_calculator.balance)
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
+    # A failed import leaves the ledger incomplete, so skip anchoring and let the next
+    # successful sync judge the wider gap.
+    # Liabilities write no entries, so they cannot affect that judgement.
+    account.set_current_balance(balance_calculator.balance) if transactions_ok && investments_ok
   end
 
   private
@@ -92,8 +95,7 @@ class PlaidAccount::Processor
           )
         end
 
-        # Returned to `process`, which creates or updates the current balance anchor
-        # valuation once transactions are in.
+        # Returned to `process`, which anchors it once transactions are in.
         #
         # Note: This is a partial implementation. In the future, we'll introduce HoldingValuation
         # to properly track the holdings vs. cash breakdown, but for now we're only tracking
@@ -103,17 +105,23 @@ class PlaidAccount::Processor
       end
     end
 
+    # Returns whether every transaction was imported, which gates the anchor in `process`.
     def process_transactions
       PlaidAccount::Transactions::Processor.new(plaid_account).process
+      true
     rescue => e
       report_exception(e)
+      false
     end
 
+    # Returns whether every investment record was imported, which gates the anchor in `process`.
     def process_investments
       PlaidAccount::Investments::TransactionsProcessor.new(plaid_account, security_resolver: security_resolver).process
       PlaidAccount::Investments::HoldingsProcessor.new(plaid_account, security_resolver: security_resolver).process
+      true
     rescue => e
       report_exception(e)
+      false
     end
 
     def process_liabilities

--- a/app/models/questrade_account/processor.rb
+++ b/app/models/questrade_account/processor.rb
@@ -27,8 +27,8 @@ class QuestradeAccount::Processor
       QuestradeAccount::ActivitiesProcessor.new(questrade_account).process
     end
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(anchor_balance) if anchor_balance
 
     account.broadcast_sync_complete
@@ -55,7 +55,6 @@ class QuestradeAccount::Processor
       account.save!
 
       # Returned to `process`, which anchors it once holdings and activities are in.
-      # The value is composed from the holdings + per-currency cash, not a made-up figure.
       total
     end
 end

--- a/app/models/questrade_account/processor.rb
+++ b/app/models/questrade_account/processor.rb
@@ -15,9 +15,9 @@ class QuestradeAccount::Processor
 
     Rails.logger.info "QuestradeAccount::Processor - Processing account #{questrade_account.id} -> Sure account #{account.id}"
 
-    # Anchor the account at its reported total (cash + holdings) and store the
-    # primary-currency cash. Non-primary cash is surfaced as holdings below.
-    update_account_balance(account)
+    # Store the reported total (cash + holdings) and the primary-currency cash.
+    # Non-primary cash is surfaced as holdings below.
+    anchor_balance = update_account_balance(account)
 
     if questrade_account.raw_holdings_payload.present? || questrade_account.non_primary_cash_entries.any?
       QuestradeAccount::HoldingsProcessor.new(questrade_account).process
@@ -26,6 +26,10 @@ class QuestradeAccount::Processor
     if questrade_account.raw_activities_payload.present?
       QuestradeAccount::ActivitiesProcessor.new(questrade_account).process
     end
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(anchor_balance) if anchor_balance
 
     account.broadcast_sync_complete
     Rails.logger.info "QuestradeAccount::Processor - Broadcast sync complete for account #{account.id}"
@@ -50,8 +54,8 @@ class QuestradeAccount::Processor
       )
       account.save!
 
-      # Current-balance anchor = the reported total (cash + holdings). The value
-      # is composed from the holdings + per-currency cash, not a made-up figure.
-      account.set_current_balance(total)
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      # The value is composed from the holdings + per-currency cash, not a made-up figure.
+      total
     end
 end

--- a/app/models/redbark_account/processor.rb
+++ b/app/models/redbark_account/processor.rb
@@ -28,8 +28,8 @@ class RedbarkAccount::Processor
       Rails.logger.warn "RedbarkAccount::Processor - No transactions payload to process"
     end
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed

--- a/app/models/redbark_account/processor.rb
+++ b/app/models/redbark_account/processor.rb
@@ -15,8 +15,7 @@ class RedbarkAccount::Processor
 
     Rails.logger.info "RedbarkAccount::Processor - Processing account #{redbark_account.id} -> Sure account #{account.id}"
 
-    # Update account balance FIRST (before processing transactions/holdings/activities)
-    update_account_balance(account)
+    anchor_balance = update_account_balance(account)
 
     # Process transactions
     transactions_count = redbark_account.raw_transactions_payload&.size || 0
@@ -28,6 +27,10 @@ class RedbarkAccount::Processor
     else
       Rails.logger.warn "RedbarkAccount::Processor - No transactions payload to process"
     end
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed
     account.broadcast_sync_complete
@@ -66,8 +69,7 @@ class RedbarkAccount::Processor
       )
       account.save!
 
-      # Create or update the current balance anchor valuation for linked accounts
-      # This is critical for reverse sync to work correctly
-      account.set_current_balance(balance)
+      # Returned to `process`, which anchors it once transactions are in.
+      balance
     end
 end

--- a/app/models/redbark_account/processor.rb
+++ b/app/models/redbark_account/processor.rb
@@ -21,16 +21,19 @@ class RedbarkAccount::Processor
     transactions_count = redbark_account.raw_transactions_payload&.size || 0
     Rails.logger.info "RedbarkAccount::Processor - Transactions payload has #{transactions_count} items"
 
+    transactions_ok = true
     if redbark_account.raw_transactions_payload.present?
       Rails.logger.info "RedbarkAccount::Processor - Processing transactions..."
-      RedbarkAccount::Transactions::Processor.new(redbark_account).process
+      transactions_ok = RedbarkAccount::Transactions::Processor.new(redbark_account).process[:success]
     else
       Rails.logger.warn "RedbarkAccount::Processor - No transactions payload to process"
     end
 
     # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
     # complete ledger. See Account::CurrentBalanceManager.
-    account.set_current_balance(anchor_balance) if anchor_balance
+    # A failed import leaves the ledger incomplete, so skip anchoring and let the next
+    # successful sync judge the wider gap.
+    account.set_current_balance(anchor_balance) if anchor_balance && transactions_ok
 
     # Trigger immediate UI refresh so entries appear in the activity feed
     account.broadcast_sync_complete

--- a/app/models/snaptrade_account/processor.rb
+++ b/app/models/snaptrade_account/processor.rb
@@ -13,9 +13,7 @@ class SnaptradeAccount::Processor
 
     Rails.logger.info "SnaptradeAccount::Processor - Processing account #{snaptrade_account.id} -> Sure account #{account.id}"
 
-    # Update account balance FIRST (before processing holdings/activities)
-    # This creates the current_anchor valuation needed for reverse sync
-    update_account_balance(account)
+    anchor_balance = update_account_balance(account)
 
     # Process holdings
     holdings_count = snaptrade_account.raw_holdings_payload&.size || 0
@@ -40,6 +38,10 @@ class SnaptradeAccount::Processor
     else
       Rails.logger.warn "SnaptradeAccount::Processor - No activities payload to process"
     end
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed
     # This is critical for fresh account links where the sync complete broadcast
@@ -67,9 +69,8 @@ class SnaptradeAccount::Processor
       )
       account.save!
 
-      # Create or update the current balance anchor valuation for linked accounts
-      # This is critical for reverse sync to work correctly
-      account.set_current_balance(total_balance)
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      total_balance
     end
 
     def calculate_total_balance

--- a/app/models/snaptrade_account/processor.rb
+++ b/app/models/snaptrade_account/processor.rb
@@ -39,8 +39,8 @@ class SnaptradeAccount::Processor
       Rails.logger.warn "SnaptradeAccount::Processor - No activities payload to process"
     end
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed

--- a/app/models/trade_republic_account/processor.rb
+++ b/app/models/trade_republic_account/processor.rb
@@ -13,8 +13,8 @@ class TradeRepublicAccount::Processor
       TradeRepublicAccount::HoldingsProcessor.new(trade_republic_account).process
       TradeRepublicAccount::ActivitiesProcessor.new(trade_republic_account).process
 
-      # Anchor the reported balance AFTER importing, so the previous reading can be judged
-      # against a complete ledger. See Account::CurrentBalanceManager.
+      # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+      # complete ledger. See Account::CurrentBalanceManager.
       account.set_current_balance(total_balance)
     end
 

--- a/app/models/trade_republic_account/processor.rb
+++ b/app/models/trade_republic_account/processor.rb
@@ -9,9 +9,13 @@ class TradeRepublicAccount::Processor
     return unless account.present?
 
     ActiveRecord::Base.transaction do
-      update_account_balance!
+      total_balance = update_account_balance!
       TradeRepublicAccount::HoldingsProcessor.new(trade_republic_account).process
       TradeRepublicAccount::ActivitiesProcessor.new(trade_republic_account).process
+
+      # Anchor the reported balance AFTER importing, so the previous reading can be judged
+      # against a complete ledger. See Account::CurrentBalanceManager.
+      account.set_current_balance(total_balance)
     end
 
     account.broadcast_sync_complete
@@ -33,6 +37,8 @@ class TradeRepublicAccount::Processor
         currency: trade_republic_account.currency
       )
       account.save!
-      account.set_current_balance(total_balance)
+
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      total_balance
     end
 end

--- a/app/models/trading212_account/processor.rb
+++ b/app/models/trading212_account/processor.rb
@@ -8,9 +8,13 @@ class Trading212Account::Processor
   def process
     return unless account.present?
 
-    update_account_balance!
+    total_balance = update_account_balance!
     Trading212Account::HoldingsProcessor.new(trading212_account).process
     Trading212Account::ActivitiesProcessor.new(trading212_account).process
+
+    # Anchor the reported balance AFTER importing, so the previous reading can be judged
+    # against a complete ledger. See Account::CurrentBalanceManager.
+    account.set_current_balance(total_balance)
 
     account.broadcast_sync_complete
   end
@@ -31,6 +35,8 @@ class Trading212Account::Processor
         currency: trading212_account.currency
       )
       account.save!
-      account.set_current_balance(total_balance)
+
+      # Returned to `process`, which anchors it once holdings and activities are in.
+      total_balance
     end
 end

--- a/app/models/trading212_account/processor.rb
+++ b/app/models/trading212_account/processor.rb
@@ -12,8 +12,8 @@ class Trading212Account::Processor
     Trading212Account::HoldingsProcessor.new(trading212_account).process
     Trading212Account::ActivitiesProcessor.new(trading212_account).process
 
-    # Anchor the reported balance AFTER importing, so the previous reading can be judged
-    # against a complete ledger. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(total_balance)
 
     account.broadcast_sync_complete

--- a/config/locales/views/admin/system_health/de.yml
+++ b/config/locales/views/admin/system_health/de.yml
@@ -2,6 +2,8 @@
 de:
   admin:
     system_health:
+      verify_worker_ai:
+        queued: Die Worker-Prüfung wurde in die Warteschlange gestellt. Das Ergebnis erscheint unten, sobald ein Worker-Prozess die Prüfung übernimmt – normalerweise innerhalb weniger Sekunden.
       show:
         title: Systemstatus
         tabs:
@@ -34,3 +36,27 @@ de:
           never: Nie
           seconds: "%{seconds} s"
           no_queues: Es sind keine Warteschlangen registriert. Möglicherweise läuft der Worker nicht.
+        ai:
+          worker:
+            title: Worker-Verifikation
+            description: Die obigen Prüfungen wurden in diesem Web-Prozess ausgeführt. Die meisten KI-Aufgaben – Antworten des Assistenten, PDF-Verarbeitung, Embeddings, automatische Kategorisierung und Händlererkennung – laufen jedoch in einem Sidekiq-Worker-Prozess. Dessen Netzwerkzugriff, DNS, Proxy-Regeln oder geladene Zugangsdaten können abweichen. Stelle eine Prüfung in die Warteschlange, um die Konfiguration und Erreichbarkeit aus Sicht eines Workers zu prüfen.
+            verify_button: Worker-Konfiguration prüfen
+            coverage_notice: Jede Prüfung erfasst genau einen Worker-Prozess – denjenigen, der sie aus der Warteschlange übernimmt. Bei mehreren Worker-Replikaten bestätigt ein erfolgreiches Ergebnis nicht, dass alle Worker funktionsfähig sind. Stelle die Prüfung erneut in die Warteschlange, um eine weitere Stichprobe zu erhalten.
+            empty:
+              title: Bisher hat kein Worker ein Prüfergebnis gemeldet
+              description: Klicke auf „Worker-Konfiguration prüfen“, um eine asynchrone Prüfung in die Warteschlange zu stellen. Das Ergebnis erscheint hier, sobald ein Worker-Prozess die Prüfung übernimmt.
+            labels:
+              process: Worker-Prozess
+              checked_at: Geprüft
+              configuration: Konfiguration
+            configuration_statuses:
+              match: Entspricht dem Web-Prozess
+              mismatch: Weicht vom Web-Prozess ab
+            statuses:
+              passing: Erfolgreich
+              failing: Fehlgeschlagen
+              stale: Veraltet
+            settings_origin:
+              title: Welche Einstellungen erfordern einen Neustart?
+              database_backed: Änderungen an Anbieter, Modell und API-Schlüssel unter Einstellungen → Self-Hosting werden in der Datenbank gespeichert. rails-settings-cached verwirft beim Speichern den gemeinsamen Cache. Web- und Worker-Prozess verwenden daher bei der nächsten Anfrage oder Aufgabe den neuen Wert – kein Neustart erforderlich.
+              env_backed: Die Embedding-Konfiguration und alle ausschließlich über Umgebungsvariablen gesetzten Werte werden beim Start des jeweiligen Containers festgelegt. Rails kann die Umgebung eines anderen Containers nicht ändern. Nach solchen Änderungen müssen daher sowohl der Web- als auch der Worker-Dienst neu gestartet oder neu erstellt werden. Wenn die Bereitstellung nur einen der Dienste neu startet oder ein Secret ohne Pod-Neustart aktualisiert, wird die Änderung nicht überall übernommen.

--- a/lib/generators/provider/family/templates/account_processor.rb.tt
+++ b/lib/generators/provider/family/templates/account_processor.rb.tt
@@ -15,8 +15,7 @@ class <%= class_name %>Account::Processor
 
     Rails.logger.info "<%= class_name %>Account::Processor - Processing account #{<%= file_name %>_account.id} -> Sure account #{account.id}"
 
-    # Update account balance FIRST (before processing transactions/holdings/activities)
-    update_account_balance(account)
+    anchor_balance = update_account_balance(account)
 <% if investment_provider? -%>
 
     # Process holdings
@@ -53,6 +52,11 @@ class <%= class_name %>Account::Processor
       Rails.logger.warn "<%= class_name %>Account::Processor - No transactions payload to process"
     end
 <% end -%>
+
+    # Anchor the reported balance AFTER importing, never before. The anchor is judged
+    # against the imported ledger, so the transactions for this sync must already be
+    # persisted when it is written. See Account::CurrentBalanceManager.
+    account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed
     account.broadcast_sync_complete
@@ -103,9 +107,8 @@ class <%= class_name %>Account::Processor
       account.save!
 <% end -%>
 
-      # Create or update the current balance anchor valuation for linked accounts
-      # This is critical for reverse sync to work correctly
-      account.set_current_balance(<%= investment_provider? ? "total_balance" : "balance" %>)
+      # Returned to `process`, which anchors it once the import is done.
+      <%= investment_provider? ? "total_balance" : "balance" %>
     end
 <% if investment_provider? -%>
 

--- a/lib/generators/provider/family/templates/account_processor.rb.tt
+++ b/lib/generators/provider/family/templates/account_processor.rb.tt
@@ -53,9 +53,8 @@ class <%= class_name %>Account::Processor
     end
 <% end -%>
 
-    # Anchor the reported balance AFTER importing, never before. The anchor is judged
-    # against the imported ledger, so the transactions for this sync must already be
-    # persisted when it is written. See Account::CurrentBalanceManager.
+    # Anchor the reported balance AFTER importing, so the standing anchor is judged against a
+    # complete ledger. See Account::CurrentBalanceManager.
     account.set_current_balance(anchor_balance) if anchor_balance
 
     # Trigger immediate UI refresh so entries appear in the activity feed

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -658,6 +658,83 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
   end
 
+  test "German worker verification copy is present without fallback" do
+    keys = %w[
+      title description verify_button coverage_notice empty.title empty.description
+      labels.process labels.checked_at labels.configuration
+      configuration_statuses.match configuration_statuses.mismatch
+      statuses.passing statuses.failing statuses.stale
+      settings_origin.title settings_origin.database_backed settings_origin.env_backed
+    ]
+    keys.each do |key|
+      assert_kind_of String, I18n.t("admin.system_health.show.ai.worker.#{key}", locale: :de, fallback: false, raise: true)
+    end
+    assert_kind_of String, I18n.t("admin.system_health.verify_worker_ai.queued", locale: :de, fallback: false, raise: true)
+  end
+
+  test "German super admin sees worker verification guidance and queued notice" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+
+    with_memory_cache do
+      with_ai_environment do
+        get admin_system_health_url(tab: "ai")
+        assert_response :success
+        assert_select "h2", text: "Worker-Verifikation"
+        assert_select "button", text: "Worker-Konfiguration prüfen"
+        assert_match(/Bisher hat kein Worker ein Prüfergebnis gemeldet/, response.body)
+        assert_match(/Jede Prüfung erfasst genau einen Worker-Prozess/, response.body)
+        assert_match(/Welche Einstellungen erfordern einen Neustart\?/, response.body)
+        assert_match(/kein Neustart erforderlich/, response.body)
+        assert_match(/sowohl der Web- als auch der Worker-Dienst/, response.body)
+
+        assert_enqueued_with(job: WorkerAiHealthCheckJob) do
+          post verify_worker_ai_admin_system_health_url
+        end
+        assert_redirected_to admin_system_health_path(tab: "ai")
+        follow_redirect!
+        assert_match(/Die Worker-Prüfung wurde in die Warteschlange gestellt/, response.body)
+      end
+    end
+  end
+
+  test "German worker results distinguish passing failing stale and differing configurations" do
+    users(:sure_support_staff).update!(locale: "de")
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+
+    with_memory_cache do
+      with_ai_environment("OPENAI_ACCESS_TOKEN" => "synthetic-token") do
+        [
+          [ {}, "Erfolgreich", "Entspricht dem Web-Prozess" ],
+          [ { llm_status: :failing, llm_model: "different-model" }, "Fehlgeschlagen", "Weicht vom Web-Prozess ab" ],
+          [ { checked_at: (WorkerAiHealth::STALE_AFTER + 1.minute).ago }, "Veraltet", "Entspricht dem Web-Prozess" ]
+        ].each do |overrides, status, configuration|
+          WorkerAiHealth.record!(worker_snapshot(**{ vector_store_adapter: :openai, vector_store_status: :passing }.merge(overrides)))
+          get admin_system_health_url(tab: "ai")
+          assert_response :success
+          assert_select "[data-testid='worker-ai-health-result']" do
+            assert_select "[data-testid='worker-process-identity']", text: "worker:1"
+            assert_select "p", text: /Geprüft vor/
+            assert_select "span", text: status
+            assert_select "span", text: configuration
+          end
+          assert_no_match(/synthetic-token/, response.body)
+        end
+      end
+    end
+  end
+
+  test "German family admin cannot queue worker verification" do
+    users(:family_admin).update!(locale: "de")
+    sign_in users(:family_admin)
+    assert_no_enqueued_jobs only: WorkerAiHealthCheckJob do
+      post verify_worker_ai_admin_system_health_url
+    end
+    assert_redirected_to root_path
+  end
+
   private
     # Stubs Rails.cache with an in-process MemoryStore for the duration of
     # the block. Test env normally runs a NullStore (see config/environments/test.rb),

--- a/test/models/account/anchor_behavior_scenarios_test.rb
+++ b/test/models/account/anchor_behavior_scenarios_test.rb
@@ -1,0 +1,407 @@
+require "test_helper"
+
+# Approach-agnostic acceptance scenarios for the "mid-day provider reading frozen as a
+# waypoint" bug.
+#
+# WHY THIS FILE DRIVES A REAL PROCESSOR INSTEAD OF Account::CurrentBalanceManager
+# ------------------------------------------------------------------------------
+# Candidate fixes disagree about *where* and *when* a stale provider reading is settled:
+#
+#   * settle it on a later sync, leaving the reading inert in the meantime
+#     (HEAD, 83d1f351b)
+#   * settle it in the same sync, after the provider's transaction batch has been imported
+#     (requires moving `set_current_balance` below the import in every processor)
+#   * settle it somewhere in between (a hook in the account sync, a differently placed
+#     waypoint, ...)
+#
+# A test that calls `Account::CurrentBalanceManager#set_current_balance` directly has to
+# pick an order for "take the reading" vs. "import the batch", and that choice alone
+# decides which of the designs above passes. So each scenario here drives one real
+# provider cycle through `PlaidAccount::Processor#process`, with only the transaction
+# sub-processor replaced by a stand-in that creates the batch's entries. The order of
+# "reading" and "import" is then whatever the implementation under test chooses, and every
+# assertion below is on what the user can observe afterwards: materialized Balance rows and
+# the valuation entries rendered in the account's activity list.
+#
+# Nothing here asserts on Valuation#kind or on how many `current_anchor` rows exist.
+#
+# Caveat for a fix that settles anchors inside `Account::Syncer#perform_sync`: balances are
+# materialized here through `Balance::Materializer` (the object `Account::Syncer` itself
+# delegates to), so such a fix must place its hook at or below the materializer, or this
+# file's `materialize!` helper must be pointed at `Account::Syncer#perform_sync` instead.
+class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
+  # Provider readings are taken mid-day (the default auto-sync cron runs at 02:22), which is
+  # the whole reason a reading is not a valid end-of-day balance for its own date.
+  SYNC_TIME_OF_DAY = "02:22"
+
+  setup do
+    @day_one = Date.current
+    @plaid_account = plaid_accounts(:one)
+
+    # accounts(:connected) is the depository linked to plaid_accounts(:one) and carries no
+    # entry fixtures - asserted rather than assumed, since every balance below is derived
+    # from the ledger this test builds.
+    assert_equal 0, accounts(:connected).entries.count
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # A. The reported bug.
+  #
+  # Discriminates: a design that freezes day one's MID-DAY reading (1000) as an end-of-day
+  # waypoint. That pins day one's close at 1000 instead of its true 600 and inflates every
+  # earlier day by the 400 that posted after the reading was taken.
+  #
+  # Passes for: any design that leaves day one's close to be derived from the ledger -
+  # whether it drops the reading immediately, or leaves it inert and settles it a sync later.
+  # Asserted twice on purpose: once immediately after the day-two sync (history must ALREADY
+  # be right - a lagging design does not get a grace period here), and once after a day-three
+  # sync (a design must not corrupt history at the moment it finally settles the reading).
+  # ---------------------------------------------------------------------------------------
+  test "a mid-day reading is not frozen as that day's closing balance" do
+    account = seed_opening_balance(1000)
+
+    # Day one, 02:22: provider reports 1000. Nothing has posted yet.
+    provider_sync!(@plaid_account, on: day(1), reading: 1000)
+
+    # Day two, 02:22: the 400 that posted after yesterday's reading arrives in this batch,
+    # dated to day one (normal for overnight PSD2 / Enable Banking batches), and the
+    # provider now reports 600.
+    provider_sync!(
+      @plaid_account,
+      on: day(2),
+      reading: 600,
+      imports: [ { date: day(1), amount: 400, name: "Card payment" } ]
+    )
+
+    materialize!(account)
+
+    day_one_row = balance_row(account, day(1))
+    assert_equal 600, day_one_row.balance,
+      "day one's CLOSING balance must be its true close (600), not the mid-day reading (1000)"
+    assert_equal 1000, day_one_row.start_cash_balance,
+      "day one opened at 1000 and closed at 600 after the 400 posted"
+
+    assert_equal 1000, balance_on(account, day(0)),
+      "the day before the reading must not be inflated by the 400 that posted after it"
+    assert_not_equal 1400, balance_on(account, day(0))
+    assert_equal 1000, balance_on(account, day(-2))
+
+    # Day three: an ordinary sync with nothing new. A design that defers settling the day-one
+    # reading settles it here; history must be unchanged.
+    provider_sync!(@plaid_account, on: day(3), reading: 600)
+
+    materialize!(account)
+
+    assert_equal 600, balance_on(account, day(1))
+    assert_equal 1000, balance_on(account, day(0))
+    assert_equal 1000, balance_on(account, day(-2))
+    assert_equal 600, balance_on(account, day(3)), "today's balance is still the provider's"
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # B. The waypoint that must survive (no regression of #1492 / #1484).
+  #
+  # The provider reading moves 1000 -> 2000 with no transaction to explain it (missing /
+  # truncated transaction history). The reverse walk subtracts only the flows it knows about,
+  # so without a provider-confirmed ground truth somewhere in the chain the whole pre-jump
+  # history silently reads 2000.
+  #
+  # Discriminates: a design that "simplifies" by always discarding the previous reading
+  # (plain revert of #1663) - every day before the jump then drifts up by 1000.
+  #
+  # Deliberately does NOT assert where the ground truth is recorded, or on which exact date
+  # the reset lands: both "waypoint on the reading's own date" and "waypoint on the day
+  # before it" leave the pre-jump history at 1000, which is the property that matters.
+  # Checked after a third sync so a design that settles a reading one sync late still counts.
+  # ---------------------------------------------------------------------------------------
+  test "history stays grounded at the provider's reading when the ledger cannot explain a move" do
+    account = seed_opening_balance(1000)
+
+    provider_sync!(@plaid_account, on: day(1), reading: 1000)
+
+    # No batch: the transaction that moved the account never reaches us.
+    provider_sync!(@plaid_account, on: day(2), reading: 2000)
+    provider_sync!(@plaid_account, on: day(3), reading: 2000)
+
+    materialize!(account)
+
+    assert_equal 2000, balance_on(account, day(3)), "today is still the provider's reading"
+
+    assert_equal 1000, balance_on(account, day(0)),
+      "the unexplained +1000 must not propagate to days before the reading that proves it"
+    assert_not_equal 2000, balance_on(account, day(0))
+    assert_equal 1000, balance_on(account, day(-2)),
+      "drift must stay bounded all the way back to the opening balance"
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # C. User-visible noise, measured at steady state.
+  #
+  # AccountsController#show renders `account.entries.excluding_split_parents.search(...)`
+  # with no filter on entryable_type or Valuation#kind, so EVERY valuation row on a linked
+  # account - provider anchor or rotated reconciliation - is a line item the user sees in the
+  # activity list. That rendered count is what this asserts; a fix that keeps a row but hides
+  # it from the ledger is equally acceptable here.
+  #
+  # Six days of ordinary syncs in which the ledger explains every move: no waypoint is
+  # warranted on any of them, so at steady state the account should carry at most the one
+  # live reading (zero if a design hides it).
+  #
+  # Discriminates: a design that rotates a "Manual balance update" into the ledger every day
+  # (one row per day), AND a design that leaves yesterday's unsettled reading sitting in the
+  # ledger next to today's (two rows forever - HEAD's deferred-settlement limitation).
+  # Counted on day six, long after any one-sync settlement lag has drained.
+  # ---------------------------------------------------------------------------------------
+  test "ordinary syncs whose ledger explains every move leave no valuation clutter behind" do
+    account = nil
+
+    # Each day's 100 posts after that day's 02:22 reading, so it arrives dated to the
+    # previous day in the next day's batch - and the reading always trails by exactly it.
+    (1..6).each do |n|
+      account = provider_sync!(
+        @plaid_account,
+        on: day(n),
+        reading: 1000 - (100 * (n - 1)),
+        imports: n == 1 ? [] : [ { date: day(n - 1), amount: 100, name: "Day #{n - 1} spend" } ]
+      )
+    end
+
+    materialize!(account)
+
+    # Guard rail: the count assertion below must not be satisfiable by throwing history away.
+    assert_equal 500, balance_on(account, day(6))
+    assert_equal 900, balance_on(account, day(1))
+
+    visible = user_visible_valuation_entries(account)
+
+    assert_operator visible.count, :<=, 1,
+      "after six explained syncs the user should see at most the live reading, " \
+      "not a daily balance-update entry and not a leftover unsettled reading " \
+      "(saw: #{visible.map { |e| [ e.date.to_s, e.name, e.amount.to_i ] }.inspect})"
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # D. Liability sign math and a multi-day gap between syncs.
+  #
+  # A credit card (liability: a positive entry amount INCREASES the balance) goes three days
+  # without a sync; the whole backlog arrives in one batch, some of it dated to the day of the
+  # last reading.
+  #
+  # Discriminates: a design that freezes the day-one reading (500) as that day's close -
+  # day one actually closed at 530 after the purchase that posted later - and any design that
+  # gets the liability sign backwards while deciding whether the batch explains the move
+  # (getting it backwards turns an explained move into an unexplained one and strands a
+  # waypoint at the wrong value). Also checks that gap length is not assumed to be one day.
+  # ---------------------------------------------------------------------------------------
+  test "a liability reading survives a multi-day gap with the right sign math" do
+    card_plaid_account = create_credit_card_plaid_account
+
+    account = provider_sync!(card_plaid_account, on: day(1), reading: 500)
+    assert_equal "liability", account.classification
+
+    seed_opening_balance(500, account: account)
+
+    # Three days later: the backlog arrives, including the purchase that posted after day
+    # one's reading. 500 + 30 + 20 - 100 = 450.
+    account = provider_sync!(
+      card_plaid_account,
+      on: day(4),
+      reading: 450,
+      imports: [
+        { date: day(1), amount: 30, name: "Purchase" },
+        { date: day(2), amount: 20, name: "Purchase" },
+        { date: day(3), amount: -100, name: "Payment" }
+      ]
+    )
+
+    materialize!(account)
+
+    assert_equal 530, balance_on(account, day(1)),
+      "day one closed at 530: the reading was taken before the 30 purchase posted"
+    assert_equal 550, balance_on(account, day(2))
+    assert_equal 450, balance_on(account, day(3))
+    assert_equal 450, balance_on(account, day(4))
+    assert_equal 500, balance_on(account, day(0)),
+      "days before the gap must not shift because of the backlog"
+
+    # Settle-later designs get their chance; history must survive it unchanged.
+    account = provider_sync!(card_plaid_account, on: day(5), reading: 450)
+    materialize!(account)
+
+    assert_equal 530, balance_on(account, day(1))
+    assert_equal 500, balance_on(account, day(0))
+    assert_equal 450, balance_on(account, day(5))
+  end
+
+  # ---------------------------------------------------------------------------------------
+  # E. Repeat syncs on the same day.
+  #
+  # Many providers sync several times a day; the second and third cycle of a day report a
+  # newer reading for a date that already has one.
+  #
+  # Discriminates: a design that treats "there is already a reading for today" as "the
+  # existing one is stale, leave it and add another" - rows accumulate within a single day -
+  # and a design that turns an intra-day superseded reading into an end-of-day waypoint,
+  # which pins day one at 1000 rather than its true 900.
+  # ---------------------------------------------------------------------------------------
+  test "repeat syncs on the same day neither accumulate rows nor freeze intra-day readings" do
+    provider_sync!(@plaid_account, on: day(1), reading: 1000)
+
+    account = provider_sync!(
+      @plaid_account,
+      on: day(2),
+      reading: 900,
+      imports: [ { date: day(1), amount: 100, name: "Yesterday's spend" } ]
+    )
+
+    rows_after_first_cycle = user_visible_valuation_entries(account).count
+
+    # Two more cycles the same day, one of them carrying a fresh batch.
+    provider_sync!(
+      @plaid_account,
+      on: day(2),
+      reading: 880,
+      imports: [ { date: day(2), amount: 20, name: "Today's spend" } ]
+    )
+    account = provider_sync!(@plaid_account, on: day(2), reading: 880)
+
+    assert_operator user_visible_valuation_entries(account).count, :<=, rows_after_first_cycle,
+      "extra sync cycles on the same day must not add valuation rows the user can see"
+
+    valuation_dates = user_visible_valuation_entries(account).map(&:date)
+    assert_equal valuation_dates.uniq.size, valuation_dates.size,
+      "the same date must never end up with more than one valuation row"
+
+    materialize!(account)
+
+    assert_equal 880, balance_on(account, day(2))
+    assert_equal 900, balance_on(account, day(1)),
+      "day one closed at 900; no intra-day reading may override that"
+  end
+
+  private
+    # day(1) is "day one" in the scenarios above; day(0) is the day before it.
+    def day(offset)
+      @day_one + (offset - 1).days
+    end
+
+    def sync_clock(date)
+      Time.zone.parse("#{date} #{SYNC_TIME_OF_DAY}")
+    end
+
+    # Always hand back a freshly loaded Account: Account::Anchorable memoizes its
+    # CurrentBalanceManager (which in turn memoizes its anchor lookup), so a long-lived
+    # instance would read state from before the sync under test.
+    def account_for(plaid_account)
+      Account.find(PlaidAccount.find(plaid_account.id).current_account.id)
+    end
+
+    # One full provider cycle, driven through the real processor so the implementation - not
+    # this test - decides whether the balance reading is taken before or after the batch is
+    # imported. Returns a fresh Account.
+    def provider_sync!(plaid_account, on:, reading:, imports: [])
+      travel_to sync_clock(on) do
+        PlaidAccount.find(plaid_account.id).update!(
+          current_balance: reading,
+          available_balance: reading
+        )
+
+        imported = []
+        stub_provider_subprocessors(plaid_account, imports, imported)
+
+        PlaidAccount::Processor.new(PlaidAccount.find(plaid_account.id)).process
+
+        # PlaidAccount::Processor#process_transactions swallows exceptions, so prove the
+        # batch actually landed instead of vanishing into a rescue.
+        assert_equal imports.size, imported.size,
+          "the provider's transaction batch did not import on #{on}"
+      end
+
+      account_for(plaid_account)
+    end
+
+    # Replaces only the transaction importer with a stand-in that creates this cycle's
+    # entries, at exactly the point in the processor where the real import happens. The other
+    # product sub-processors are no-ops (nothing in these scenarios needs holdings, trades or
+    # liability statements).
+    def stub_provider_subprocessors(plaid_account, imports, imported)
+      importer = Object.new
+      importer.define_singleton_method(:process) do
+        imports.each do |txn|
+          account = Account.find(PlaidAccount.find(plaid_account.id).current_account.id)
+
+          entry = account.entries.create!(
+            date: txn[:date],
+            name: txn[:name] || "Imported transaction",
+            amount: txn[:amount],
+            currency: txn[:currency] || account.currency,
+            entryable: Transaction.new
+          )
+
+          imported << entry.id
+        end
+      end
+
+      PlaidAccount::Transactions::Processor.stubs(:new).returns(importer)
+      PlaidAccount::Investments::TransactionsProcessor.any_instance.stubs(:process)
+      PlaidAccount::Investments::HoldingsProcessor.any_instance.stubs(:process)
+      PlaidAccount::Liabilities::CreditProcessor.any_instance.stubs(:process)
+      PlaidAccount::Liabilities::MortgageProcessor.any_instance.stubs(:process)
+      PlaidAccount::Liabilities::StudentLoanProcessor.any_instance.stubs(:process)
+    end
+
+    # Gives the account a history to be wrong about: without an opening anchor the reverse
+    # walk stops at the oldest entry and there are no "earlier days" to inflate.
+    def seed_opening_balance(amount, account: nil)
+      account ||= accounts(:connected)
+
+      account.entries.create!(
+        date: day(-4),
+        name: "Opening balance",
+        amount: amount,
+        currency: account.currency,
+        entryable: Valuation.new(kind: "opening_anchor")
+      )
+
+      Account.find(account.id)
+    end
+
+    def create_credit_card_plaid_account
+      PlaidAccount.create!(
+        plaid_item: plaid_items(:one),
+        plaid_id: "acc_mock_credit_card",
+        name: "Test Credit Card",
+        plaid_type: "credit",
+        plaid_subtype: "credit card",
+        currency: "USD",
+        current_balance: 500,
+        available_balance: 500
+      )
+    end
+
+    def materialize!(account)
+      Balance::Materializer.new(Account.find(account.id), strategy: :reverse).materialize_balances
+    end
+
+    def balance_row(account, date)
+      row = Account.find(account.id).balances.find_by(date: date, currency: account.currency)
+      assert_not_nil row, "expected a materialized balance for #{date}"
+      row
+    end
+
+    def balance_on(account, date)
+      balance_row(account, date).balance
+    end
+
+    # What the user actually sees: AccountsController#show builds the activity list from
+    # `account.entries.excluding_split_parents.search(@q)` with no filter on entryable_type
+    # or Valuation#kind, and entries/_entry.html.erb renders a valuation through the same row
+    # template as a transaction. So every valuation entry here is a visible line item.
+    def user_visible_valuation_entries(account)
+      Account.find(account.id)
+        .entries
+        .excluding_split_parents
+        .where(entryable_type: "Valuation")
+        .order(:date)
+    end
+end

--- a/test/models/account/anchor_behavior_scenarios_test.rb
+++ b/test/models/account/anchor_behavior_scenarios_test.rb
@@ -1,34 +1,13 @@
 require "test_helper"
 
-# Approach-agnostic acceptance scenarios for the "mid-day provider reading frozen as a
-# waypoint" bug.
+# End-to-end acceptance scenarios for the "mid-day provider reading frozen as a waypoint" bug.
 #
-# WHY THIS FILE DRIVES A REAL PROCESSOR INSTEAD OF Account::CurrentBalanceManager
-# ------------------------------------------------------------------------------
-# Candidate fixes disagree about *where* and *when* a stale provider reading is settled:
-#
-#   * settle it on a later sync, leaving the reading inert in the meantime
-#     (HEAD, 83d1f351b)
-#   * settle it in the same sync, after the provider's transaction batch has been imported
-#     (requires moving `set_current_balance` below the import in every processor)
-#   * settle it somewhere in between (a hook in the account sync, a differently placed
-#     waypoint, ...)
-#
-# A test that calls `Account::CurrentBalanceManager#set_current_balance` directly has to
-# pick an order for "take the reading" vs. "import the batch", and that choice alone
-# decides which of the designs above passes. So each scenario here drives one real
-# provider cycle through `PlaidAccount::Processor#process`, with only the transaction
-# sub-processor replaced by a stand-in that creates the batch's entries. The order of
-# "reading" and "import" is then whatever the implementation under test chooses, and every
-# assertion below is on what the user can observe afterwards: materialized Balance rows and
-# the valuation entries rendered in the account's activity list.
-#
-# Nothing here asserts on Valuation#kind or on how many `current_anchor` rows exist.
-#
-# Caveat for a fix that settles anchors inside `Account::Syncer#perform_sync`: balances are
-# materialized here through `Balance::Materializer` (the object `Account::Syncer` itself
-# delegates to), so such a fix must place its hook at or below the materializer, or this
-# file's `materialize!` helper must be pointed at `Account::Syncer#perform_sync` instead.
+# Each scenario drives one real provider cycle through `PlaidAccount::Processor#process` with
+# only the transaction sub-processor replaced by a stand-in, so the processor - not the test -
+# decides whether the balance reading is taken before or after the batch is imported. Every
+# assertion is on what the user can observe afterwards: materialized Balance rows and the
+# valuation entries rendered in the account's activity list. Nothing here asserts on
+# Valuation#kind or on how many `current_anchor` rows exist.
 class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
   # Provider readings are taken mid-day (the default auto-sync cron runs at 02:22), which is
   # the whole reason a reading is not a valid end-of-day balance for its own date.
@@ -38,25 +17,16 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
     @day_one = Date.current
     @plaid_account = plaid_accounts(:one)
 
-    # accounts(:connected) is the depository linked to plaid_accounts(:one) and carries no
-    # entry fixtures - asserted rather than assumed, since every balance below is derived
-    # from the ledger this test builds.
+    # accounts(:connected) is the depository linked to plaid_accounts(:one); asserted rather
+    # than assumed, since every balance below is derived from the ledger this test builds.
     assert_equal 0, accounts(:connected).entries.count
   end
 
-  # ---------------------------------------------------------------------------------------
-  # A. The reported bug.
-  #
-  # Discriminates: a design that freezes day one's MID-DAY reading (1000) as an end-of-day
-  # waypoint. That pins day one's close at 1000 instead of its true 600 and inflates every
-  # earlier day by the 400 that posted after the reading was taken.
-  #
-  # Passes for: any design that leaves day one's close to be derived from the ledger -
-  # whether it drops the reading immediately, or leaves it inert and settles it a sync later.
-  # Asserted twice on purpose: once immediately after the day-two sync (history must ALREADY
-  # be right - a lagging design does not get a grace period here), and once after a day-three
-  # sync (a design must not corrupt history at the moment it finally settles the reading).
-  # ---------------------------------------------------------------------------------------
+  # A. The reported bug. Freezing day one's MID-DAY reading (1000) as an end-of-day waypoint
+  # pins day one's close at 1000 instead of its true 600 and inflates every earlier day by the
+  # 400 that posted after the reading was taken. Asserted immediately after the day-two sync
+  # AND again after a quiet day-three sync, so neither a lagging fix nor one that corrupts
+  # history when it finally settles the reading can pass.
   test "a mid-day reading is not frozen as that day's closing balance" do
     account = seed_opening_balance(1000)
 
@@ -98,22 +68,10 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
     assert_equal 600, balance_on(account, day(3)), "today's balance is still the provider's"
   end
 
-  # ---------------------------------------------------------------------------------------
-  # B. The waypoint that must survive (no regression of #1492 / #1484).
-  #
-  # The provider reading moves 1000 -> 2000 with no transaction to explain it (missing /
-  # truncated transaction history). The reverse walk subtracts only the flows it knows about,
-  # so without a provider-confirmed ground truth somewhere in the chain the whole pre-jump
-  # history silently reads 2000.
-  #
-  # Discriminates: a design that "simplifies" by always discarding the previous reading
-  # (plain revert of #1663) - every day before the jump then drifts up by 1000.
-  #
-  # Deliberately does NOT assert where the ground truth is recorded, or on which exact date
-  # the reset lands: both "waypoint on the reading's own date" and "waypoint on the day
-  # before it" leave the pre-jump history at 1000, which is the property that matters.
-  # Checked after a third sync so a design that settles a reading one sync late still counts.
-  # ---------------------------------------------------------------------------------------
+  # B. The waypoint that must survive (no regression of #1492 / #1484). The reading moves
+  # 1000 -> 2000 with no transaction to explain it (missing / truncated history). Without a
+  # provider-confirmed ground truth somewhere in the chain, the reverse walk silently reads
+  # 2000 all the way back. Deliberately does not assert WHERE that ground truth is recorded.
   test "history stays grounded at the provider's reading when the ledger cannot explain a move" do
     account = seed_opening_balance(1000)
 
@@ -134,24 +92,10 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
       "drift must stay bounded all the way back to the opening balance"
   end
 
-  # ---------------------------------------------------------------------------------------
-  # C. User-visible noise, measured at steady state.
-  #
-  # AccountsController#show renders `account.entries.excluding_split_parents.search(...)`
-  # with no filter on entryable_type or Valuation#kind, so EVERY valuation row on a linked
-  # account - provider anchor or rotated reconciliation - is a line item the user sees in the
-  # activity list. That rendered count is what this asserts; a fix that keeps a row but hides
-  # it from the ledger is equally acceptable here.
-  #
-  # Six days of ordinary syncs in which the ledger explains every move: no waypoint is
-  # warranted on any of them, so at steady state the account should carry at most the one
-  # live reading (zero if a design hides it).
-  #
-  # Discriminates: a design that rotates a "Manual balance update" into the ledger every day
-  # (one row per day), AND a design that leaves yesterday's unsettled reading sitting in the
-  # ledger next to today's (two rows forever - HEAD's deferred-settlement limitation).
-  # Counted on day six, long after any one-sync settlement lag has drained.
-  # ---------------------------------------------------------------------------------------
+  # C. User-visible clutter at steady state. AccountsController#show renders every valuation
+  # row on a linked account as a line item (no filter on entryable_type or Valuation#kind), so
+  # six days of fully explained syncs must leave at most the one live reading behind - not a
+  # daily "Manual balance update", and not a leftover unsettled reading.
   test "ordinary syncs whose ledger explains every move leave no valuation clutter behind" do
     account = nil
 
@@ -180,19 +124,10 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
       "(saw: #{visible.map { |e| [ e.date.to_s, e.name, e.amount.to_i ] }.inspect})"
   end
 
-  # ---------------------------------------------------------------------------------------
-  # D. Liability sign math and a multi-day gap between syncs.
-  #
-  # A credit card (liability: a positive entry amount INCREASES the balance) goes three days
-  # without a sync; the whole backlog arrives in one batch, some of it dated to the day of the
-  # last reading.
-  #
-  # Discriminates: a design that freezes the day-one reading (500) as that day's close -
-  # day one actually closed at 530 after the purchase that posted later - and any design that
-  # gets the liability sign backwards while deciding whether the batch explains the move
-  # (getting it backwards turns an explained move into an unexplained one and strands a
-  # waypoint at the wrong value). Also checks that gap length is not assumed to be one day.
-  # ---------------------------------------------------------------------------------------
+  # D. Liability sign math across a multi-day gap. On a credit card a positive entry amount
+  # INCREASES the balance; getting that backwards turns an explained move into an unexplained
+  # one and strands a waypoint at the wrong value. Also checks that gap length is not assumed
+  # to be one day.
   test "a liability reading survives a multi-day gap with the right sign math" do
     card_plaid_account = create_credit_card_plaid_account
 
@@ -233,17 +168,9 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
     assert_equal 450, balance_on(account, day(5))
   end
 
-  # ---------------------------------------------------------------------------------------
-  # E. Repeat syncs on the same day.
-  #
-  # Many providers sync several times a day; the second and third cycle of a day report a
-  # newer reading for a date that already has one.
-  #
-  # Discriminates: a design that treats "there is already a reading for today" as "the
-  # existing one is stale, leave it and add another" - rows accumulate within a single day -
-  # and a design that turns an intra-day superseded reading into an end-of-day waypoint,
-  # which pins day one at 1000 rather than its true 900.
-  # ---------------------------------------------------------------------------------------
+  # E. Repeat syncs on the same day (many providers sync several times a day) must neither
+  # accumulate valuation rows nor turn a superseded intra-day reading into an end-of-day
+  # waypoint, which would pin day one at 1000 rather than its true 900.
   test "repeat syncs on the same day neither accumulate rows nor freeze intra-day readings" do
     provider_sync!(@plaid_account, on: day(1), reading: 1000)
 
@@ -279,6 +206,57 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
       "day one closed at 900; no intra-day reading may override that"
   end
 
+  # F. A reading already carried forward onto a date contains the flows dated on that date.
+  # Re-counting them decides an explained move is unexplained, freezes day two's 14:00 reading
+  # (500) as that day's close, and inflates every earlier day by the 50 that posted after it.
+  # True day-two close = 1000 - 400 - 100 - 50 = 450, exactly what the provider reports on
+  # day three, so nothing here is ambiguous.
+  test "a reading carried forward is not re-settled against flows it already contains" do
+    account = seed_opening_balance(1000)
+
+    provider_sync!(@plaid_account, on: day(1), reading: 1000)
+
+    # Day two, 02:22: yesterday's 400 arrives; 1000 -> 600 is fully explained.
+    provider_sync!(
+      @plaid_account,
+      on: day(2),
+      reading: 600,
+      imports: [ { date: day(1), amount: 400, name: "Day 1 spend" } ]
+    )
+
+    # Day two, second cycle: 100 posts today and the reading follows it down.
+    provider_sync!(
+      @plaid_account,
+      on: day(2),
+      reading: 500,
+      imports: [ { date: day(2), amount: 100, name: "Day 2 spend (early)" } ]
+    )
+
+    # Day three: the 50 that posted after day two's last reading arrives, dated to day two.
+    account = provider_sync!(
+      @plaid_account,
+      on: day(3),
+      reading: 450,
+      imports: [ { date: day(2), amount: 50, name: "Day 2 spend (late)" } ]
+    )
+
+    materialize!(account)
+
+    assert_equal 450, balance_on(account, day(2)),
+      "day two closed at 450; the 500 reading was taken before the last 50 posted"
+    assert_equal 600, balance_on(account, day(1))
+    assert_equal 1000, balance_on(account, day(0)),
+      "days before the reading must not be inflated by what posted after it"
+    assert_equal 450, balance_on(account, day(3))
+
+    # Excludes only the opening balance this test seeded itself, so the count is about
+    # rows the syncs produced - and stays kind-agnostic, like the rest of this file.
+    visible = user_visible_valuation_entries(account).reject { |e| e.date == day(-4) }
+    assert_operator visible.count, :<=, 1,
+      "every move here is explained by the ledger, so no waypoint is warranted " \
+      "(saw: #{visible.map { |e| [ e.date.to_s, e.name, e.amount.to_i ] }.inspect})"
+  end
+
   private
     # day(1) is "day one" in the scenarios above; day(0) is the day before it.
     def day(offset)
@@ -290,15 +268,12 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
     end
 
     # Always hand back a freshly loaded Account: Account::Anchorable memoizes its
-    # CurrentBalanceManager (which in turn memoizes its anchor lookup), so a long-lived
-    # instance would read state from before the sync under test.
+    # CurrentBalanceManager, which memoizes its anchor lookup.
     def account_for(plaid_account)
       Account.find(PlaidAccount.find(plaid_account.id).current_account.id)
     end
 
-    # One full provider cycle, driven through the real processor so the implementation - not
-    # this test - decides whether the balance reading is taken before or after the batch is
-    # imported. Returns a fresh Account.
+    # One full provider cycle, driven through the real processor. Returns a fresh Account.
     def provider_sync!(plaid_account, on:, reading:, imports: [])
       travel_to sync_clock(on) do
         PlaidAccount.find(plaid_account.id).update!(
@@ -320,10 +295,8 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
       account_for(plaid_account)
     end
 
-    # Replaces only the transaction importer with a stand-in that creates this cycle's
-    # entries, at exactly the point in the processor where the real import happens. The other
-    # product sub-processors are no-ops (nothing in these scenarios needs holdings, trades or
-    # liability statements).
+    # Replaces only the transaction importer with a stand-in that creates this cycle's entries
+    # at exactly the point where the real import happens; the other sub-processors are no-ops.
     def stub_provider_subprocessors(plaid_account, imports, imported)
       importer = Object.new
       importer.define_singleton_method(:process) do
@@ -394,9 +367,8 @@ class AnchorBehaviorScenariosTest < ActiveSupport::TestCase
     end
 
     # What the user actually sees: AccountsController#show builds the activity list from
-    # `account.entries.excluding_split_parents.search(@q)` with no filter on entryable_type
-    # or Valuation#kind, and entries/_entry.html.erb renders a valuation through the same row
-    # template as a transaction. So every valuation entry here is a visible line item.
+    # `account.entries.excluding_split_parents.search(@q)`, and entries/_entry.html.erb renders
+    # a valuation through the same row template as a transaction.
     def user_visible_valuation_entries(account)
       Account.find(account.id)
         .entries

--- a/test/models/account/current_balance_manager_test.rb
+++ b/test/models/account/current_balance_manager_test.rb
@@ -208,40 +208,193 @@ class Account::CurrentBalanceManagerTest < ActiveSupport::TestCase
     assert_equal 1000, @linked_account.balance
   end
 
-  test "preserves previous day anchor as reconciliation when updating linked account balance" do
-    # First create a current anchor
+  test "judges a stale anchor immediately: preserves it as a waypoint when the ledger cannot explain the change" do
+    day_one = Date.current
     manager = Account::CurrentBalanceManager.new(@linked_account)
-    result = manager.set_current_balance(1000)
-    assert result.success?
+    assert manager.set_current_balance(1000).success?
 
-    current_anchor = @linked_account.valuations.current_anchor.first
-    original_id = current_anchor.id
+    original_id = @linked_account.valuations.current_anchor.first.id
 
-    # Travel to tomorrow to ensure date change
-    travel_to Date.current + 1.day do
-      # Now update it
+    # Precondition, asserted rather than left to fixture luck: nothing can explain 1000 -> 2000
+    assert_equal 0, @linked_account.entries.transactions.count
+
+    travel_to day_one + 1.day do
+      day_two_manager = Account::CurrentBalanceManager.new(@linked_account)
+
+      # One promotion + one create: the old anchor is left behind as a waypoint and a
+      # fresh anchor is created for today. Judged NOW, not on some later sync.
       assert_difference -> { @linked_account.entries.count } => 1,
-                       -> { @linked_account.valuations.count } => 1 do
-        result = manager.set_current_balance(2000)
+                        -> { @linked_account.valuations.count } => 1 do
+        result = day_two_manager.set_current_balance(2000)
         assert result.success?
         assert result.changes_made?
       end
 
-      # The old anchor should now be a reconciliation
-      preserved_valuation = Valuation.find(original_id)
-      assert_equal "reconciliation", preserved_valuation.kind
-      assert_equal 1000, preserved_valuation.entry.amount
-      assert_equal Valuation.build_reconciliation_name(@linked_account.accountable_type), preserved_valuation.entry.name
-      assert_equal Date.yesterday, preserved_valuation.entry.date
+      promoted = Valuation.find(original_id)
+      assert_equal "reconciliation", promoted.kind
+      assert_equal 1000, promoted.entry.amount
+      assert_equal day_one, promoted.entry.date
+      assert_equal Valuation.build_reconciliation_name(@linked_account.accountable_type), promoted.entry.name
 
-      # A new current anchor should exist for today
-      new_anchor = @linked_account.valuations.current_anchor.first
-      assert_not_equal original_id, new_anchor.id
-      assert_equal 2000, new_anchor.entry.amount
-      assert_equal Date.current, new_anchor.entry.date
+      # Exactly one current_anchor: the freshly created one for today.
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+      assert_equal 1, @linked_account.valuations.reconciliation.count
+
+      assert_equal 2000, day_two_manager.current_balance
+      assert_equal Date.current, day_two_manager.current_date
     end
 
     assert_equal 2000, @linked_account.balance
+  end
+
+  test "moves a stale anchor forward when the imported ledger explains the balance change" do
+    day_one = Date.current
+    manager = Account::CurrentBalanceManager.new(@linked_account)
+    assert manager.set_current_balance(1000).success?
+    stale_id = @linked_account.valuations.current_anchor.first.id
+
+    travel_to day_one + 1.day do
+      # Processors now import transactions BEFORE anchoring, so day one's entries are
+      # already persisted by the time set_current_balance judges the old anchor.
+      @linked_account.entries.create!(
+        date: day_one,
+        name: "Card payment",
+        amount: 400,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      day_two_manager = Account::CurrentBalanceManager.new(@linked_account)
+
+      # The anchor just moves forward in place: no destroy, no create. Net row delta
+      # is ZERO.
+      assert_no_difference -> { @linked_account.entries.count } do
+        assert_no_difference -> { @linked_account.valuations.count } do
+          assert day_two_manager.set_current_balance(600).success?
+        end
+      end
+
+      moved = Valuation.find(stale_id)
+      assert_equal "current_anchor", moved.kind
+      assert_equal 600, moved.entry.amount
+      assert_equal Date.current, moved.entry.date
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+      assert_empty @linked_account.valuations.reconciliation
+    end
+  end
+
+  # The bug this change exists for is not "a row has the wrong kind", it is "every day
+  # before the waypoint is off by whatever posted after the mid-day reading". Assert that
+  # directly: promoting day one's 1000 reading would pin day one's close at 1000 instead
+  # of the true 600, inflating all earlier history by 400.
+  test "an anchor that moves forward leaves the day's materialized balance at its true close" do
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+
+    travel_to day_one + 1.day do
+      @linked_account.entries.create!(
+        date: day_one,
+        name: "Card payment",
+        amount: 400,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(600).success?
+
+      Balance::Materializer.new(@linked_account, strategy: :reverse).materialize_balances
+
+      day_one_balance = @linked_account.balances.find_by(date: day_one, currency: "USD")
+      assert_equal 600, day_one_balance.balance
+      assert_equal 1000, day_one_balance.start_cash_balance
+    end
+  end
+
+  test "moves a stale anchor forward on a liability account using liability sign math" do
+    card = accounts(:credit_card)
+    card.update!(plaid_account: plaid_accounts(:one))
+    assert card.linked?
+
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(card).set_current_balance(500).success?
+    stale_id = card.valuations.current_anchor.first.id
+
+    travel_to day_one + 1.day do
+      # Positive amount on a liability means "debt increased"
+      card.entries.create!(
+        date: day_one,
+        name: "Purchase",
+        amount: 30,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(card).set_current_balance(530).success?
+
+      moved = Valuation.find(stale_id)
+      assert_equal "current_anchor", moved.kind
+      assert_empty card.valuations.reconciliation
+      assert_equal 1, card.valuations.current_anchor.count
+    end
+  end
+
+  test "moves a stale anchor forward across a multi-day gap" do
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+    stale_id = @linked_account.valuations.current_anchor.first.id
+
+    travel_to day_one + 3.days do
+      @linked_account.entries.create!(date: day_one, name: "Fee", amount: 20, currency: "USD", entryable: Transaction.new)
+      @linked_account.entries.create!(date: day_one + 1.day, name: "Deposit", amount: -50, currency: "USD", entryable: Transaction.new)
+      @linked_account.entries.create!(date: day_one + 2.days, name: "Coffee", amount: 10, currency: "USD", entryable: Transaction.new)
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1020).success?
+
+      moved = Valuation.find(stale_id)
+      assert_equal "current_anchor", moved.kind
+      assert_empty @linked_account.valuations.reconciliation
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+    end
+  end
+
+  test "preserves a stale anchor when the explaining window mixes currencies" do
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+    stale_id = @linked_account.valuations.current_anchor.first.id
+
+    travel_to day_one + 1.day do
+      @linked_account.entries.create!(
+        date: day_one,
+        name: "Foreign card payment",
+        amount: 400,
+        currency: "EUR",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(600).success?
+
+      assert_equal "reconciliation", Valuation.find(stale_id).kind
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+    end
+  end
+
+  test "does not move a stale anchor forward on an investment account" do
+    investment = accounts(:investment)
+    investment.update!(plaid_account: plaid_accounts(:one))
+    assert investment.linked?
+
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(investment).set_current_balance(1000).success?
+    stale_id = investment.valuations.current_anchor.first.id
+
+    travel_to day_one + 1.day do
+      investment.entries.create!(date: day_one, name: "Withdrawal", amount: 400, currency: "USD", entryable: Transaction.new)
+
+      assert Account::CurrentBalanceManager.new(investment).set_current_balance(600).success?
+
+      assert_equal "reconciliation", Valuation.find(stale_id).kind
+      assert_equal 1, investment.valuations.current_anchor.count
+    end
   end
 
   test "does not preserve same-day anchor as reconciliation" do

--- a/test/models/account/current_balance_manager_test.rb
+++ b/test/models/account/current_balance_manager_test.rb
@@ -283,6 +283,116 @@ class Account::CurrentBalanceManagerTest < ActiveSupport::TestCase
     end
   end
 
+  # An anchor moved forward in place carries the flows dated on its new date inside its own
+  # amount. Re-summing that date on the next sync counts them twice, makes the move look
+  # unexplained, and freezes a mid-day reading as a waypoint - the #1492 / #1484 corruption
+  # this change exists to remove. Needs three syncs to reach; no other test goes that far.
+  test "an anchor already moved forward in place is not double counted on the next sync" do
+    day_one = Date.current
+    day_two = day_one + 1.day
+    day_three = day_one + 2.days
+
+    # Day one, 02:22: the provider reports 1000 and nothing has posted yet.
+    travel_to Time.zone.parse("#{day_one} 02:22") do
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+    end
+
+    anchor_id = @linked_account.valuations.current_anchor.first.id
+
+    # Day two, 02:22: yesterday's 400 arrives in today's batch. The ledger explains
+    # 1000 -> 600, so the anchor moves forward IN PLACE to day two / 600.
+    travel_to Time.zone.parse("#{day_two} 02:22") do
+      @linked_account.entries.create!(
+        date: day_one,
+        name: "Day 1 spend",
+        amount: 400,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(600).success?
+    end
+
+    # Precondition for the bug, asserted rather than assumed.
+    assert_equal "current_anchor", Valuation.find(anchor_id).kind
+    assert_equal day_two, Valuation.find(anchor_id).entry.date
+
+    # Day two, 14:00: a second cycle the same day. 100 posts, dated to day two, and the
+    # reading drops to 500. Same-day update, so the anchor's amount now BAKES IN that 100.
+    travel_to Time.zone.parse("#{day_two} 14:00") do
+      @linked_account.entries.create!(
+        date: day_two,
+        name: "Day 2 spend (early)",
+        amount: 100,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(500).success?
+    end
+
+    assert_equal 500, Valuation.find(anchor_id).entry.amount
+    assert_equal day_two, Valuation.find(anchor_id).entry.date
+
+    # Day three, 02:22: the 50 that posted after yesterday's last reading arrives, dated
+    # to day two. True day-two close = 1000 - 400 - 100 - 50 = 450, and 450 is exactly what
+    # the provider now reports. The only flow NOT already inside the anchor's 500 is that 50,
+    # so the ledger fully explains 500 -> 450 and the anchor should just move forward again.
+    travel_to Time.zone.parse("#{day_three} 02:22") do
+      @linked_account.entries.create!(
+        date: day_two,
+        name: "Day 2 spend (late)",
+        amount: 50,
+        currency: "USD",
+        entryable: Transaction.new
+      )
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(450).success?
+
+      moved = Valuation.find(anchor_id)
+      assert_equal "current_anchor", moved.kind,
+        "the day-two 100 is already inside the anchor's 500; re-summing it makes an explained " \
+        "move look unexplained and freezes a mid-day reading as a waypoint"
+      assert_empty @linked_account.valuations.reconciliation
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+      assert_equal day_three, moved.entry.date
+      assert_equal 450, moved.entry.amount
+    end
+  end
+
+  # `current_anchor_valuation` picks the newest of several anchor rows, but max_by over an
+  # unordered query needs an explicit tiebreak to resolve a same-date tie. Duplicates are
+  # reachable: the only guard is Entry's app-level date uniqueness validation (no DB index).
+  test "current anchor lookup resolves a same-date duplicate to the newest row" do
+    anchor_name = Valuation.build_current_anchor_name(@linked_account.accountable_type)
+
+    @linked_account.entries.create!(
+      date: Date.current,
+      name: anchor_name,
+      amount: 100,
+      currency: "USD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+
+    # How such a row exists in production: pre-dating the validation, inserted via raw SQL,
+    # or written by a second in-flight transaction that could not see the first one commit.
+    duplicate = @linked_account.entries.new(
+      date: Date.current,
+      name: anchor_name,
+      amount: 9999,
+      currency: "USD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+    duplicate.save!(validate: false)
+
+    assert_equal 2, @linked_account.valuations.current_anchor.count
+
+    manager = Account::CurrentBalanceManager.new(@linked_account)
+
+    assert_equal 9999, manager.current_balance,
+      "with two anchors tied on date the newest row must win"
+  end
+
   # The bug this change exists for is not "a row has the wrong kind", it is "every day
   # before the waypoint is off by whatever posted after the mid-day reading". Assert that
   # directly: promoting day one's 1000 reading would pin day one's close at 1000 instead
@@ -375,6 +485,55 @@ class Account::CurrentBalanceManagerTest < ActiveSupport::TestCase
 
       assert_equal "reconciliation", Valuation.find(stale_id).kind
       assert_equal 1, @linked_account.valuations.current_anchor.count
+    end
+  end
+
+  # A provider can correct an account's currency between syncs, leaving the standing anchor's
+  # own entry denominated in the old code. Rotating is the only path that replaces it with a
+  # reading in the current currency.
+  test "preserves a stale anchor whose own currency no longer matches the account" do
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+    stale_id = @linked_account.valuations.current_anchor.first.id
+    assert_equal "USD", Valuation.find(stale_id).entry.currency
+
+    travel_to day_one + 1.day do
+      # No transactions were imported, so the flow window is empty and the flow-currency
+      # check passes vacuously.
+      @linked_account.update!(currency: "EUR")
+
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+
+      assert_equal "reconciliation", Valuation.find(stale_id).kind
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+
+      fresh = @linked_account.valuations.current_anchor.first
+      assert_equal "EUR", fresh.entry.currency
+      assert_equal day_one + 1.day, fresh.entry.date
+    end
+  end
+
+  test "preserves a stale-currency anchor even when every flow matches the new currency" do
+    day_one = Date.current
+    assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(1000).success?
+    stale_id = @linked_account.valuations.current_anchor.first.id
+
+    travel_to day_one + 1.day do
+      @linked_account.update!(currency: "EUR")
+      @linked_account.entries.create!(
+        date: day_one + 1.day,
+        name: "Coffee",
+        amount: 20,
+        currency: "EUR",
+        entryable: Transaction.new
+      )
+
+      # 1000 - 20 == 980 satisfies the ledger identity numerically, but the 1000 is USD.
+      assert Account::CurrentBalanceManager.new(@linked_account).set_current_balance(980).success?
+
+      assert_equal "reconciliation", Valuation.find(stale_id).kind
+      assert_equal 1, @linked_account.valuations.current_anchor.count
+      assert_equal "EUR", @linked_account.valuations.current_anchor.first.entry.currency
     end
   end
 

--- a/test/models/coinstats_account/processor_test.rb
+++ b/test/models/coinstats_account/processor_test.rb
@@ -146,6 +146,52 @@ class CoinstatsAccount::ProcessorTest < ActiveSupport::TestCase
     assert_equal "GBP", @account.currency
   end
 
+  # The transactions processor reports partial failure by returning `success: false` rather
+  # than raising, so anchoring must honour that flag. Depository-backed because
+  # Account::CurrentBalanceManager#ledger_explains? only does real work for :cash accounts.
+  test "a discarded failed transaction import must not freeze the standing anchor as a reconciliation" do
+    cash_account = @family.accounts.create!(
+      accountable: Depository.new,
+      name: "CoinStats-linked Checking",
+      balance: 1000,
+      cash_balance: 1000,
+      currency: "USD"
+    )
+
+    cs_account = @coinstats_item.coinstats_accounts.create!(
+      name: "Checking",
+      currency: "USD",
+      current_balance: 940
+    )
+    AccountProvider.create!(account: cash_account, provider: cs_account)
+
+    anchor_date = 2.days.ago.to_date
+    cash_account.entries.create!(
+      date: anchor_date,
+      name: Valuation.build_current_anchor_name("Depository"),
+      amount: 1000,
+      currency: "USD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+
+    CoinstatsAccount::HoldingsProcessor.any_instance.stubs(:process)
+
+    # The 60.00 of activity that explains the drop from 1000 to 940 never lands: every
+    # row failed, and the importer says so in its return value rather than by raising.
+    CoinstatsAccount::Transactions::Processor.any_instance.stubs(:process).returns(
+      { success: false, total: 3, imported: 0, failed: 3, errors: [] }
+    )
+
+    CoinstatsAccount::Processor.new(cs_account).process
+
+    cash_account.reload
+
+    assert_equal 0, cash_account.valuations.reconciliation.count,
+      "an import that reported success: false must not freeze the standing anchor as a reconciliation waypoint"
+    assert_equal anchor_date, cash_account.valuations.current_anchor.sole.entry.date,
+      "the standing anchor must be left alone until a sync with a complete ledger can judge it"
+  end
+
   test "raises error when account update fails" do
     # Make the account invalid by directly modifying a validation constraint
     Account.any_instance.stubs(:update!).raises(ActiveRecord::RecordInvalid.new(@account))

--- a/test/models/enable_banking_account/processor_test.rb
+++ b/test/models/enable_banking_account/processor_test.rb
@@ -47,6 +47,7 @@ class EnableBankingAccount::ProcessorTest < ActiveSupport::TestCase
     @enable_banking_account.update_columns(current_balance: nil)
 
     EnableBankingAccount::Transactions::Processor.any_instance.expects(:process).once
+      .returns({ success: true, total: 0, imported: 0, skipped: 0, failed: 0, errors: [] })
 
     assert_no_changes -> { @account.reload.cash_balance } do
       EnableBankingAccount::Processor.new(@enable_banking_account).process

--- a/test/models/enable_banking_account_processor_test.rb
+++ b/test/models/enable_banking_account_processor_test.rb
@@ -50,6 +50,53 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
 
     assert_equal BigDecimal("250"), acct.reload.cash_balance
   end
+  test "anchors the current balance only after transactions have been imported" do
+    eb_acct = @item.enable_banking_accounts.create!(
+      name: "Checking",
+      uid: "eb_4",
+      currency: "GBP",
+      current_balance: BigDecimal("250")
+    )
+
+    acct = accounts(:depository)
+    acct.update!(balance: 500, cash_balance: 500, currency: "GBP")
+    AccountProvider.create!(account: acct, provider: eb_acct)
+
+    baseline_transaction_count = acct.entries.transactions.count
+
+    # Stand-in transaction importer: creates one entry, the way a real provider batch
+    # would, so we can observe whether it landed before the anchor was written. Mocha
+    # evaluates a `.with` block as a parameter matcher, which can run more than once per
+    # invocation, so the side effect is guarded to fire only the first time.
+    imported = false
+    EnableBankingAccount::Transactions::Processor.any_instance.stubs(:process).with do
+      unless imported
+        imported = true
+        acct.entries.create!(
+          date: Date.current,
+          name: "Imported transaction",
+          amount: 10,
+          currency: "GBP",
+          entryable: Transaction.new
+        )
+      end
+      true
+    end
+
+    observed_transaction_count = nil
+
+    Account.any_instance.stubs(:set_current_balance).with do
+      observed_transaction_count ||= acct.entries.transactions.count
+      true
+    end.returns(Account::CurrentBalanceManager::Result.new(success?: true, changes_made?: true, error: nil))
+
+    EnableBankingAccount::Processor.new(eb_acct).process
+
+    assert_equal baseline_transaction_count + 1, observed_transaction_count,
+      "set_current_balance must be called AFTER the sync's transactions are persisted, " \
+      "so a stale anchor can be judged against a complete ledger"
+  end
+
   test "snapshot upsert preserves an established currency when the payload omits it" do
     eb_acct = @item.enable_banking_accounts.create!(name: "Checking", uid: "eb_3", currency: "GBP")
 

--- a/test/models/enable_banking_account_processor_test.rb
+++ b/test/models/enable_banking_account_processor_test.rb
@@ -81,7 +81,7 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
         )
       end
       true
-    end
+    end.returns({ success: true, total: 1, imported: 1, skipped: 0, failed: 0, errors: [] })
 
     observed_transaction_count = nil
 
@@ -97,6 +97,34 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
       "so a stale anchor can be judged against a complete ledger"
   end
 
+  # Anchoring now happens AFTER the import and permanently decides whether the standing anchor
+  # moves forward or is frozen as a waypoint, so it must not run on a ledger the import left
+  # incomplete. #process_transactions can fail two ways: by raising, or by reporting
+  # `success: false` from its per-row rescues. The bank reads 940 either way because the
+  # customer spent 60.00 since the anchor was taken, and that spend never lands.
+  test "a swallowed transaction import exception must not freeze the standing anchor as a reconciliation" do
+    eb_acct, acct, anchor_date = link_account_with_standing_anchor(uid: "eb_f4_raise")
+
+    EnableBankingAccount::Transactions::Processor.any_instance
+      .stubs(:process).raises(StandardError, "provider 500")
+
+    EnableBankingAccount::Processor.new(eb_acct).process
+
+    assert_standing_anchor_untouched(acct, anchor_date)
+  end
+
+  test "a transaction import that reports success false must not freeze the standing anchor as a reconciliation" do
+    eb_acct, acct, anchor_date = link_account_with_standing_anchor(uid: "eb_f4_result")
+
+    EnableBankingAccount::Transactions::Processor.any_instance.stubs(:process).returns(
+      { success: false, total: 3, imported: 0, skipped: 0, failed: 3, errors: [] }
+    )
+
+    EnableBankingAccount::Processor.new(eb_acct).process
+
+    assert_standing_anchor_untouched(acct, anchor_date)
+  end
+
   test "snapshot upsert preserves an established currency when the payload omits it" do
     eb_acct = @item.enable_banking_accounts.create!(name: "Checking", uid: "eb_3", currency: "GBP")
 
@@ -105,4 +133,41 @@ class EnableBankingAccountProcessorTest < ActiveSupport::TestCase
     assert_equal "GBP", eb_acct.reload.currency,
       "an omitted payload currency must not reset an established account to EUR"
   end
+
+  private
+    # A linked EUR account standing at 1000 on an anchor two days old, with the provider now
+    # reporting 940. Returns [enable_banking_account, account, anchor_date].
+    def link_account_with_standing_anchor(uid:)
+      eb_acct = @item.enable_banking_accounts.create!(
+        name: "Checking",
+        uid: uid,
+        currency: "EUR",
+        current_balance: BigDecimal("940")
+      )
+
+      acct = accounts(:depository)
+      acct.entries.destroy_all
+      acct.update!(balance: 1000, cash_balance: 1000, currency: "EUR")
+      AccountProvider.create!(account: acct, provider: eb_acct)
+
+      anchor_date = 2.days.ago.to_date
+      acct.entries.create!(
+        date: anchor_date,
+        name: Valuation.build_current_anchor_name("Depository"),
+        amount: 1000,
+        currency: "EUR",
+        entryable: Valuation.new(kind: "current_anchor")
+      )
+
+      [ eb_acct, acct, anchor_date ]
+    end
+
+    def assert_standing_anchor_untouched(acct, anchor_date)
+      acct.reload
+
+      assert_equal 0, acct.valuations.reconciliation.count,
+        "an incomplete import must not freeze the standing anchor as a reconciliation waypoint"
+      assert_equal anchor_date, acct.valuations.current_anchor.sole.entry.date,
+        "the standing anchor must be left alone until a sync with a complete ledger can judge it"
+    end
 end

--- a/test/models/plaid_account/processor_test.rb
+++ b/test/models/plaid_account/processor_test.rb
@@ -229,6 +229,60 @@ class PlaidAccount::ProcessorTest < ActiveSupport::TestCase
     assert_not_equal original_balance, original_anchor.entry.amount
   end
 
+  # PlaidAccount::Transactions::Processor has no per-row rescue, so a malformed row aborts the
+  # batch mid-loop and #process_transactions swallows the exception, leaving a half-imported
+  # ledger that the standing anchor must not be judged against.
+  test "a partially imported, swallowed transaction batch must not freeze the standing anchor as a reconciliation" do
+    PlaidAccount::Investments::TransactionsProcessor.any_instance.stubs(:process)
+    PlaidAccount::Investments::HoldingsProcessor.any_instance.stubs(:process)
+
+    account = @plaid_account.current_account
+    account.entries.destroy_all
+    account.update!(balance: 1000, cash_balance: 1000, currency: "USD")
+
+    anchor_date = 2.days.ago.to_date
+    account.entries.create!(
+      date: anchor_date,
+      name: Valuation.build_current_anchor_name("Depository"),
+      amount: 1000,
+      currency: "USD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+
+    # 30 + 20 + 10 of spend is exactly what explains the drop from 1000 to 940, but the
+    # second row has no transaction_id, so Account::ProviderImportAdapter#import_transaction
+    # raises on it: row 1 is already persisted and row 3 never runs.
+    posted_on = 1.day.ago.to_date.to_s
+
+    @plaid_account.update!(
+      current_balance: 940,
+      available_balance: 940,
+      raw_transactions_payload: {
+        "added" => [
+          { "transaction_id" => "f4_row_1", "amount" => 30, "iso_currency_code" => "USD",
+            "date" => posted_on, "original_description" => "Row 1" },
+          { "amount" => 20, "iso_currency_code" => "USD",
+            "date" => posted_on, "original_description" => "Row 2 (no transaction_id)" },
+          { "transaction_id" => "f4_row_3", "amount" => 10, "iso_currency_code" => "USD",
+            "date" => posted_on, "original_description" => "Row 3" }
+        ],
+        "modified" => [],
+        "removed" => []
+      }
+    )
+
+    PlaidAccount::Processor.new(@plaid_account).process
+
+    account.reload
+
+    assert_equal 1, account.entries.transactions.count,
+      "sanity: the batch must have aborted after its first row, leaving a partial ledger"
+    assert_equal 0, account.valuations.reconciliation.count,
+      "a swallowed, partially applied import must not freeze the standing anchor as a reconciliation waypoint"
+    assert_equal anchor_date, account.valuations.current_anchor.sole.entry.date,
+      "the standing anchor must be left alone until a sync with a complete ledger can judge it"
+  end
+
   private
     def expect_investment_product_processor_calls
       PlaidAccount::Investments::TransactionsProcessor.any_instance.expects(:process).once

--- a/test/models/redbark_account/processor_test.rb
+++ b/test/models/redbark_account/processor_test.rb
@@ -124,4 +124,54 @@ class RedbarkAccount::ProcessorTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal 0, result[:total]
   end
+
+  # Pins the other side of the gate below: a clean import must still anchor.
+  test "processor anchors the reported balance after a successful transaction import" do
+    @redbark_account.update!(
+      current_balance: 940,
+      raw_transactions_payload: [
+        { "id" => "txn_1", "amount" => "60.00", "date" => Date.current.to_s }
+      ]
+    )
+
+    RedbarkAccount::Processor.new(@redbark_account).process
+
+    assert_equal Date.current, @account.valuations.current_anchor.sole.entry.date
+  end
+
+  # The transactions processor reports partial failure by returning `success: false` rather
+  # than raising, so anchoring must honour that flag. Depository-backed because
+  # Account::CurrentBalanceManager#ledger_explains? only does real work for :cash accounts.
+  test "a discarded failed transaction import must not freeze the standing anchor as a reconciliation" do
+    anchor_date = 2.days.ago.to_date
+    @account.entries.create!(
+      date: anchor_date,
+      name: Valuation.build_current_anchor_name("Depository"),
+      amount: 1000,
+      currency: "AUD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+
+    @redbark_account.update!(
+      current_balance: 940,
+      raw_transactions_payload: [
+        { "id" => "txn_1", "amount" => "-60.00", "date" => Date.current.to_s }
+      ]
+    )
+
+    # The 60.00 of activity that explains the drop from 1000 to 940 never lands: every row
+    # failed, and the importer says so in its return value rather than by raising.
+    RedbarkAccount::Transactions::Processor.any_instance.stubs(:process).returns(
+      { success: false, total: 1, imported: 0, skipped: 0, failed: 1, errors: [] }
+    )
+
+    RedbarkAccount::Processor.new(@redbark_account).process
+
+    @account.reload
+
+    assert_equal 0, @account.valuations.reconciliation.count,
+      "an import that reported success: false must not freeze the standing anchor as a reconciliation waypoint"
+    assert_equal anchor_date, @account.valuations.current_anchor.sole.entry.date,
+      "the standing anchor must be left alone until a sync with a complete ledger can judge it"
+  end
 end

--- a/test/models/redbark_account/processor_test.rb
+++ b/test/models/redbark_account/processor_test.rb
@@ -125,17 +125,35 @@ class RedbarkAccount::ProcessorTest < ActiveSupport::TestCase
     assert_equal 0, result[:total]
   end
 
-  # Pins the other side of the gate below: a clean import must still anchor.
+  # Pins the other side of the gate below: a clean import must still anchor. A standing anchor
+  # is required for the assertion to mean anything: without one `ledger_explains?` is never
+  # consulted and the anchor lands on Date.current whichever order the two steps run in.
   test "processor anchors the reported balance after a successful transaction import" do
+    anchor_date = 2.days.ago.to_date
+    @account.entries.create!(
+      date: anchor_date,
+      name: Valuation.build_current_anchor_name("Depository"),
+      amount: 1000,
+      currency: "AUD",
+      entryable: Valuation.new(kind: "current_anchor")
+    )
+
+    # CDR pre-signed: negative is a debit, so this is the 60 of spending that explains the
+    # drop from 1000 to 940. Import it first and the anchor moves forward in place; anchor
+    # first and the ledger cannot explain the gap, so it freezes as a reconciliation.
     @redbark_account.update!(
       current_balance: 940,
       raw_transactions_payload: [
-        { "id" => "txn_1", "amount" => "60.00", "date" => Date.current.to_s }
+        { "id" => "txn_1", "amount" => "-60.00", "date" => Date.current.to_s }
       ]
     )
 
     RedbarkAccount::Processor.new(@redbark_account).process
 
+    @account.reload
+
+    assert_equal 0, @account.valuations.reconciliation.count,
+      "an import that explains the balance move must let the anchor slide forward, not leave a waypoint"
     assert_equal Date.current, @account.valuations.current_anchor.sole.entry.date
   end
 


### PR DESCRIPTION
## Problem

Linked accounts accumulate one "Manual balance update" entry per day. Several Enable Banking users reported it on Discord (BBVA, Sabadell, N26). The visible entries are the symptom; the corrupted history behind them is the bug. This fixes #3291

On every sync, `Account::CurrentBalanceManager` saves the provider-reported balance as a `current_anchor` valuation dated today. On the next day's sync, `preserve_anchor_as_reconciliation_if_stale` converted yesterday's anchor into a `reconciliation` and renamed it, which renders as "Manual balance update" for depository accounts.

The problem is timing. That anchor holds whatever the provider reported at the moment the sync ran — the default auto-sync runs at **02:22** — but `Balance::ReverseCalculator:34` treats a reconciliation as that day's **closing** balance and hard-resets end-of-day to it. Any transaction that posts later the same day lands on the wrong side of the waypoint, and every balance before that date shifts.

```
Day 1, 02:22 sync   bank says 100        →  current_anchor(Day 1, 100)
Day 1, afternoon    two payments of −20 post, both dated Day 1
                    the account really closes Day 1 at 60
Day 2, 02:22 sync   the payments import
                    Day 1's anchor is frozen as a waypoint of 100
                    a new anchor is created for Day 2 at 60
```

Working backwards from Day 2:

| date | closing | opening | why |
|---|---|---|---|
| Day 2 | 60 | 60 | anchor, nothing posted today |
| Day 1 | **100** | **140** | reset to the waypoint, then the −40 reversed back out of it |

Day 1 closes at 100 when the bank closed it at 60. Day 0 inherits 140. Everything earlier is inflated by 40.

## What this changes

We keep #1663 because when a provider gives incomplete transaction history (as reported in #1492, #1484) we need the anchor. This PR adds a refinement on when the anchor has to be there.

The rotation could not be made conditional where it stood, because **every processor set the balance before importing transactions**. At the moment the old code rotated the anchor, the entries that would explain the move had not landed yet. Therefore, in this PR we change the ordering so that each processor now anchors the reported balance **after** its import:

| Processor | Before | After |
|---|---|---|
| `plaid_account` | `process_account!` (anchors) → transactions → investments → liabilities | `process_account!` → transactions → investments → liabilities → **anchor** |
| `enable_banking_account` | `process_account!` (anchors) → transactions | `process_account!` → transactions → **anchor** |
| `coinstats_account` | holdings → `process_account!` (anchors) → transactions | holdings → `process_account!` → transactions → **anchor** |
| `redbark_account` | `update_account_balance` (anchors) → transactions | `update_account_balance` → transactions → **anchor** |
| `indexa_capital_account`, `snaptrade_account`, `questrade_account` | `update_account_balance` (anchors) → holdings → activities | `update_account_balance` → holdings → activities → **anchor** |
| `ibkr_account`, `trade_republic_account`, `trading212_account` | `update_account_balance!` (anchors) → holdings → activities | `update_account_balance!` → holdings → activities → **anchor** |

Each balance-update step now **returns** the balance it computed instead of anchoring inline, and `process` passes that value to `set_current_balance` once the import is done. No processor holds the balance in instance state. The same change is applied to `lib/generators/provider/family/templates/account_processor.rb.tt`, so new providers are generated with the correct ordering and a comment stating it as a contract.

With the ledger complete, `set_current_balance_for_linked_account` judges the standing anchor at the point it would overwrite it:

- the imported transactions **explain** the move to today's reading → the anchor carries nothing they don't already carry, so it moves forward in place (date *and* amount), exactly like a same-day update;
- they **don't** → the provider knew something the ledger doesn't, so it is preserved as a reconciliation waypoint and a fresh anchor is created for today.

```
expected = older + (asset? ? -net : net)
```

Steady state for a healthy linked cash account: **one** `current_anchor` row, the live one, and **zero** system-generated "Manual balance update" rows.

### Scope

Restricted to `:cash` accounts. For `:investment` the reported total moves with market prices and trades only shift cash ↔ holdings, so the identity means nothing; those accounts keep today's behaviour. Mixed-currency windows bail rather than guess an FX rate.

Only this account's own system-created anchors are ever touched: `kind: "current_anchor"` is written in exactly one place, so a user's reconciliation can never be reached. `Entry`'s date-uniqueness validation (scoped to `[account_id, entryable_type]`) means an account holds at most one valuation per date, so the promote path can never collide.

## Known residuals

- The single live `current_anchor` is still visible in the activity feed as "Current balance", because `current_anchor` is not filtered anywhere in `app/views`, `app/components`, `app/controllers` or `app/helpers`. 
- `ledger_explains?` returns `false` on any entry whose currency differs from the account's, so an account with occasional foreign-currency transactions lands in the preserve branch more often than it should.
- Plaid reports `balances.current` including pending for credit-type accounts (`plaid_account/processor.rb:130`), while `ledger_explains?` uses `excluding_pending` to match the calculators. Those accounts will more often land in the preserve branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Current balances are now anchored after transactions, holdings, and activities finish importing, improving sync accuracy.
  * Failed or incomplete imports no longer update balance anchors or create reconciliation waypoints.
  * Balance waypoints are preserved when ledger activity cannot explain a provider-reported change or currencies do not match.
  * Explained changes update existing waypoints without unnecessary reconciliation entries.
  * Improved handling for liabilities, multi-day gaps, repeated same-day syncs, duplicate entries, and pre-existing balance activity.

* **Tests**
  * Expanded coverage for balance anchoring, reconciliation behavior, and sync ordering across supported account types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->