### PR TITLE
fix(l10n): localize German T-Invest logo notice

### DIFF
--- a/config/locales/views/settings/hostings/de.yml
+++ b/config/locales/views/settings/hostings/de.yml
@@ -261,6 +261,7 @@ de:
         description: Trag einen T-Invest-API-Token mit Lesezugriff ein. Er holt Logos zu Wertpapieren – auch für Fonds und Anleihen, deren Kurse von MOEX kommen – und, wenn oben aktiviert, Kurse russischer Papiere.
         env_configured_message: Über die Umgebungsvariable TINKOFF_INVEST_API_KEY eingerichtet.
         label: API-Token
+        moex_only_notice: Oben nicht für Kursdaten aktiviert – sobald ein Token eingerichtet ist, ruft T-Invest unabhängig vom obigen Kontrollkästchen Logos für alle deine Wertpapiere ab.
         placeholder: T-Invest-API-Token hier eintragen
         show_details: "(Details anzeigen)"
         step_1: Öffne bei T-Bank den Bereich Investments, dann Einstellungen, dann API-Tokens (setzt ein eröffnetes Depot bei T-Bank voraus).

--- a/test/controllers/settings/hostings_controller_test.rb
+++ b/test/controllers/settings/hostings_controller_test.rb
@@ -803,11 +803,18 @@ class Settings::HostingsControllerTest < ActionDispatch::IntegrationTest
     with_self_hosting do
       patch settings_hosting_url, params: { setting: { securities_providers: [ "moex_public" ] } }
 
-      get settings_hosting_url
+      notices = {
+        en: "Not enabled for prices above — T-Invest is used to fetch brand logos for all your securities whenever a token is configured, independent of the checkbox above.",
+        de: "Oben nicht für Kursdaten aktiviert – sobald ein Token eingerichtet ist, ruft T-Invest unabhängig vom obigen Kontrollkästchen Logos für alle deine Wertpapiere ab."
+      }
+      notices.each do |locale, notice|
+        get settings_hosting_url(locale: locale)
 
-      assert_response :success
-      assert_select "input[name='setting[tinkoff_invest_api_key]']"
-      assert_includes response.body, I18n.t("settings.hostings.tinkoff_invest_settings.moex_only_notice")
+        assert_response :success
+        assert_select "input[name='setting[tinkoff_invest_api_key]']"
+        assert_includes response.body, notice
+        assert_equal notice, I18n.t("settings.hostings.tinkoff_invest_settings.moex_only_notice", locale: locale, fallback: false, raise: true)
+      end
     end
   ensure
     Setting.securities_providers = ""


### PR DESCRIPTION
## Summary

German self-hosting settings now explain in German that T-Invest can fetch security logos even when it is not selected for pricing. Previously, this notice fell back to English.

Provider selection, token handling, and English wording are unchanged. The copy follows the existing German terminology and informal register; an independent AI language review approved it.

## Validation

- The existing controller test now checks rendered English and German notices and fallback-disabled lookups. It failed on the German text before the fix.
- Focused controller and locale tests: 61 runs, 416 assertions, no failures or errors; four existing skips.
- Full Rails suite with `TZ=UTC`: 8,718 runs, 35,322 assertions, no failures or errors; 33 existing skips.
- RuboCop, ERB lint, Biome, and Brakeman passed. Correctness, testing, and standards reviews found no issues.
- A synthetic browser check passed at widths 1024, 1440, and 500; the notice and token field remained visible without text clipping.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this adds one translation and changes no provider operations or configuration behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a German-language notice explaining that T-Invest fetches security logos whenever a token is configured, regardless of market-price data settings.

* **Tests**
  * Expanded coverage to verify the T-Invest notice in both English and German locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->