### PR TITLE
Fix onboarding guide asset paths

### DIFF
--- a/app/controllers/settings/guides_controller.rb
+++ b/app/controllers/settings/guides_controller.rb
@@ -13,6 +13,11 @@ class Settings::GuidesController < ApplicationController
       strikethrough: true,
       superscript: true
     )
-    @guide_content = markdown.render(File.read(Rails.root.join("docs/onboarding/guide.md")))
+    guide_source = File.read(Rails.root.join("docs/onboarding/guide.md"))
+    guide_source.gsub!(/src="assets\/([^"]+)"/) do
+      %(src="#{helpers.asset_path(Regexp.last_match(1))}")
+    end
+
+    @guide_content = markdown.render(guide_source)
   end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,3 +6,6 @@ Rails.application.config.assets.version = "1.0"
 # Add additional assets to the asset load path.
 Rails.application.config.assets.paths << "app/components"
 Rails.application.config.importmap.cache_sweepers << Rails.root.join("app/components")
+
+# Serve screenshots embedded by the in-app onboarding guide.
+Rails.application.config.assets.paths << Rails.root.join("docs/onboarding/assets")

--- a/test/controllers/settings/guides_controller_test.rb
+++ b/test/controllers/settings/guides_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Settings::GuidesControllerTest < ActionDispatch::IntegrationTest
+  test "guide images use asset pipeline paths" do
+    sign_in users(:family_admin)
+
+    get settings_guides_path
+
+    assert_response :success
+    assert_select 'img[src^="/assets/guide-create-account"]', count: 1
+    assert_select 'img[src^="assets/"]', count: 0
+  end
+end


### PR DESCRIPTION
Resolve screenshots embedded in the in-app onboarding guide through the Rails asset pipeline and add the onboarding asset directory to the asset load path.

Adds controller coverage that verifies rendered guide image URLs use `/assets/...` paths.

Tests intentionally skipped at request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Onboarding guide images now load correctly using the application’s asset paths.
  - Prevents broken image references caused by relative asset URLs.

- **Tests**
  - Added coverage to verify the onboarding guide renders successfully and uses valid asset URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->