### PR TITLE
feat(providers): show Brandfetch logos on Bank Sync and Accounts

### DIFF
--- a/app/components/DS/filled_icon.html.erb
+++ b/app/components/DS/filled_icon.html.erb
@@ -6,6 +6,6 @@
   <% if icon %>
     <%= helpers.icon(icon, size: icon_size, color: "current") %>
   <% elsif text %>
-    <%= tag.span text.first, class: text_classes %>
+    <%= tag.span text.first(text_length), class: text_classes %>
   <% end %>
 <% end %>

--- a/app/components/DS/filled_icon.rb
+++ b/app/components/DS/filled_icon.rb
@@ -1,5 +1,5 @@
 class DS::FilledIcon < DesignSystemComponent
-  attr_reader :icon, :text, :hex_color, :size, :rounded, :variant, :description, :aria_hidden
+  attr_reader :icon, :text, :hex_color, :size, :rounded, :variant, :description, :aria_hidden, :text_length, :class_name
 
   VARIANTS = %i[default text surface container inverse].freeze
 
@@ -35,7 +35,7 @@ class DS::FilledIcon < DesignSystemComponent
   # "Apple" → "A"). The single letter is decorative — relying on AT
   # users to infer "Apple" from "A" is broken. Use `description:` to
   # surface the full label, or ensure the adjacent text node carries it.
-  def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false, description: nil, aria_hidden: nil)
+  def initialize(variant: :default, icon: nil, text: nil, hex_color: nil, size: "md", rounded: false, description: nil, aria_hidden: nil, text_length: 1, class_name: nil)
     @variant = variant.to_sym
     @icon = icon
     @text = text
@@ -44,6 +44,8 @@ class DS::FilledIcon < DesignSystemComponent
     @rounded = rounded
     @description = description.presence
     @aria_hidden = aria_hidden.nil? ? @description.blank? : aria_hidden
+    @text_length = text_length
+    @class_name = class_name
   end
 
   def container_classes
@@ -51,7 +53,8 @@ class DS::FilledIcon < DesignSystemComponent
       "flex justify-center items-center shrink-0",
       size_classes,
       radius_classes,
-      transparent? ? "border" : solid_bg_class
+      transparent? ? "border" : solid_bg_class,
+      class_name
     )
   end
 

--- a/app/components/provider_logo.html.erb
+++ b/app/components/provider_logo.html.erb
@@ -1,10 +1,13 @@
 <%= tag.span class: class_names("relative block overflow-hidden shrink-0", class_name) do %>
-  <%= tag.span class: class_names("absolute inset-0 flex items-center justify-center", metadata[:logo_bg]), aria: { hidden: true } do %>
-    <% if metadata[:logo_icon] %>
-      <%= helpers.icon metadata[:logo_icon], size: "sm", color: "white" %>
-    <% else %>
-      <span class="text-xs font-bold text-inverse"><%= metadata[:logo_text] %></span>
-    <% end %>
+  <%= tag.span class: "absolute inset-0", aria: { hidden: true } do %>
+    <%= render DS::FilledIcon.new(
+          icon: fallback_icon,
+          text: fallback_text,
+          text_length: 2,
+          hex_color: fallback_color,
+          rounded: rounded?,
+          class_name: class_names("w-full h-full", rounded? ? "rounded-full" : "rounded-lg")
+        ) %>
   <% end %>
   <% if (url = brand_url) %>
     <%= helpers.image_tag url, class: "absolute inset-0 w-full h-full bg-container", alt: "", loading: "lazy", onerror: ProviderLogo::REMOVE_ON_ERROR %>

--- a/app/components/provider_logo.html.erb
+++ b/app/components/provider_logo.html.erb
@@ -1,0 +1,12 @@
+<%= tag.span class: class_names("relative block overflow-hidden shrink-0", class_name) do %>
+  <%= tag.span class: class_names("absolute inset-0 flex items-center justify-center", metadata[:logo_bg]), aria: { hidden: true } do %>
+    <% if metadata[:logo_icon] %>
+      <%= helpers.icon metadata[:logo_icon], size: "sm", color: "white" %>
+    <% else %>
+      <span class="text-xs font-bold text-inverse"><%= metadata[:logo_text] %></span>
+    <% end %>
+  <% end %>
+  <% if (url = brand_url) %>
+    <%= helpers.image_tag url, class: "absolute inset-0 w-full h-full bg-container", alt: "", loading: "lazy", onerror: ProviderLogo::REMOVE_ON_ERROR %>
+  <% end %>
+<% end %>

--- a/app/components/provider_logo.rb
+++ b/app/components/provider_logo.rb
@@ -24,4 +24,20 @@ class ProviderLogo < ApplicationComponent
   def metadata
     @metadata ||= Provider::Metadata.for(@provider_key)
   end
+
+  def fallback_icon
+    metadata[:logo_icon]
+  end
+
+  def fallback_text
+    metadata[:logo_text]
+  end
+
+  def fallback_color
+    metadata[:logo_color]
+  end
+
+  def rounded?
+    class_name.to_s.include?("rounded-full")
+  end
 end

--- a/app/components/provider_logo.rb
+++ b/app/components/provider_logo.rb
@@ -1,0 +1,27 @@
+# Renders a sync provider's own logo, falling back in order:
+#   1. the provider's brand icon from Brandfetch (needs a domain and a client ID)
+#   2. the provider's generic icon (`logo_icon`), for providers with no brand
+#   3. the provider's initials (`logo_text`)
+#
+# The fallback is always rendered and the Brandfetch image is laid over it on an
+# opaque background. Brandfetch is asked for a 404 rather than its lettermark
+# when it doesn't know the brand, and a failed image removes itself to reveal
+# the fallback.
+class ProviderLogo < ApplicationComponent
+  REMOVE_ON_ERROR = "this.remove()".freeze
+
+  def initialize(provider_key:, class_name: "w-8 h-8 rounded-full")
+    @provider_key = provider_key
+    @class_name = class_name
+  end
+
+  attr_reader :class_name
+
+  def brand_url
+    Provider::Metadata.logo_url(@provider_key)
+  end
+
+  def metadata
+    @metadata ||= Provider::Metadata.for(@provider_key)
+  end
+end

--- a/app/components/settings/provider_card.html.erb
+++ b/app/components/settings/provider_card.html.erb
@@ -2,9 +2,7 @@
             class: "bg-container shadow-border-xs hover:bg-surface-inset rounded-xl p-4 flex flex-col gap-2.5 text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alpha-black-300",
             data: { turbo_frame: "drawer", turbo_prefetch: "false" }.merge(filter_data) do %>
   <div class="flex items-start gap-2.5">
-    <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 <%= logo_bg %>">
-      <span class="text-xs font-bold text-inverse"><%= logo_text %></span>
-    </div>
+    <%= render ProviderLogo.new(provider_key: provider_key, class_name: "w-9 h-9 rounded-lg") %>
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2 flex-wrap">
         <span class="text-sm font-medium text-primary"><%= name %></span>

--- a/app/components/settings/provider_card.rb
+++ b/app/components/settings/provider_card.rb
@@ -9,8 +9,7 @@ class Settings::ProviderCard < ApplicationComponent
     I18n.t(key) if key
   end
 
-  def initialize(provider_key:, name:, tagline: nil, region: nil, kinds: nil, tier: nil,
-                 maturity: :stable, logo_bg: "bg-gray-500", logo_text: nil)
+  def initialize(provider_key:, name:, tagline: nil, region: nil, kinds: nil, tier: nil, maturity: :stable)
     @provider_key = provider_key
     @name         = name
     @tagline      = tagline
@@ -18,11 +17,9 @@ class Settings::ProviderCard < ApplicationComponent
     @kinds        = Array(kinds).compact
     @tier         = tier
     @maturity     = maturity.to_sym
-    @logo_bg      = logo_bg
-    @logo_text    = logo_text || name.first(2).upcase
   end
 
-  attr_reader :name, :tagline, :logo_bg, :logo_text
+  attr_reader :provider_key, :name, :tagline
 
   def maturity_label
     self.class.maturity_label(@maturity)

--- a/app/models/provider/metadata.rb
+++ b/app/models/provider/metadata.rb
@@ -1,34 +1,34 @@
 class Provider
   module Metadata
     REGISTRY = {
-      akahu:          { region: "NZ",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "AK", logo_bg: "bg-emerald-600", domain: "akahu.nz" },
-      simplefin:      { region: "US",      kinds: %w[Bank Investment], maturity: :stable, logo_text: "SF", logo_bg: "bg-blue-600",    domain: "simplefin.org" },
-      lunchflow:      { region: "Global",  kinds: %w[Bank],            maturity: :stable, logo_text: "LF", logo_bg: "bg-orange-500",  domain: "lunchflow.app" },
-      up:             { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "UP", logo_bg: "bg-orange-600",  domain: "up.com.au" },
-      monobank:       { region: "UA",      kinds: %w[Bank],            maturity: :alpha,  logo_text: "MB", logo_bg: "bg-inverse",     domain: "monobank.ua" },
-      enable_banking: { region: "EU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "EB", logo_bg: "bg-purple-600",  domain: "enablebanking.com" },
-      coinstats:      { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CS", logo_bg: "bg-pink-600",    domain: "coinstats.app" },
-      wise:           { region: "Global",  kinds: %w[Bank],            maturity: :beta,   logo_text: "WI", logo_bg: "bg-green-500",   domain: "wise.com" },
-      mercury:        { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "ME", logo_bg: "bg-cyan-600",    domain: "mercury.com" },
-      brex:           { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "BX", logo_bg: "bg-emerald-600", domain: "brex.com" },
-      coinbase:       { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CB", logo_bg: "bg-blue-500",    domain: "coinbase.com" },
-      binance:        { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "BI", logo_bg: "bg-yellow-600",  domain: "binance.com" },
-      kraken:         { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "KR", logo_bg: "bg-violet-600",  domain: "kraken.com" },
-      snaptrade:      { region: "US / CA", kinds: %w[Investment],      maturity: :beta,   logo_text: "ST", logo_bg: "bg-green-600",   domain: "snaptrade.com" },
-      ibkr:           { region: "Global",  kinds: %w[Investment],      maturity: :beta,   logo_text: "IB", logo_bg: "bg-red-600",     domain: "interactivebrokers.com" },
-      indexa_capital: { region: "ES",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "IC", logo_bg: "bg-red-600",     domain: "indexacapital.com" },
-      sophtron:       { region: "US",      kinds: %w[Bank Investment], maturity: :alpha,  logo_text: "SO", logo_bg: "bg-teal-600",    domain: "sophtron.com" },
-      trading212:     { region: "EU",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "T2", logo_bg: "bg-teal-600",    domain: "trading212.com" },
-      trade_republic: { region: "EU",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "TR", logo_bg: "bg-primary",     domain: "traderepublic.com" },
-      plaid:          { region: "US",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600",  domain: "plaid.com", tier: "Paid" },
-      plaid_eu:       { region: "EU",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600",  domain: "plaid.com", tier: "Paid", name: "Plaid EU" },
-      questrade:      { region: "CA",      kinds: %w[Investment],      maturity: :beta,   logo_text: "QT", logo_bg: "bg-teal-600",    domain: "questrade.com" },
-      redbark:        { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "RB", logo_bg: "bg-red-700",     domain: "redbark.com" },
-      onchain_wallet: { region: "Global",  kinds: %w[Crypto],          maturity: :alpha,  logo_text: "OC", logo_bg: "bg-amber-600",   domain: nil, logo_icon: "wallet", name: "On-chain wallets" }
+      akahu:          { region: "NZ",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "AK", logo_color: "#059669", domain: "akahu.nz" },
+      simplefin:      { region: "US",      kinds: %w[Bank Investment], maturity: :stable, logo_text: "SF", logo_color: "#2563eb", domain: "simplefin.org" },
+      lunchflow:      { region: "Global",  kinds: %w[Bank],            maturity: :stable, logo_text: "LF", logo_color: "#f97316", domain: "lunchflow.app" },
+      up:             { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "UP", logo_color: "#ea580c", domain: "up.com.au" },
+      monobank:       { region: "UA",      kinds: %w[Bank],            maturity: :alpha,  logo_text: "MB", logo_color: "#111827", domain: "monobank.ua" },
+      enable_banking: { region: "EU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "EB", logo_color: "#9333ea", domain: "enablebanking.com" },
+      coinstats:      { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CS", logo_color: "#db2777", domain: "coinstats.app" },
+      wise:           { region: "Global",  kinds: %w[Bank],            maturity: :beta,   logo_text: "WI", logo_color: "#22c55e", domain: "wise.com" },
+      mercury:        { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "ME", logo_color: "#0891b2", domain: "mercury.com" },
+      brex:           { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "BX", logo_color: "#059669", domain: "brex.com" },
+      coinbase:       { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CB", logo_color: "#3b82f6", domain: "coinbase.com" },
+      binance:        { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "BI", logo_color: "#ca8a04", domain: "binance.com" },
+      kraken:         { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "KR", logo_color: "#7c3aed", domain: "kraken.com" },
+      snaptrade:      { region: "US / CA", kinds: %w[Investment],      maturity: :beta,   logo_text: "ST", logo_color: "#16a34a", domain: "snaptrade.com" },
+      ibkr:           { region: "Global",  kinds: %w[Investment],      maturity: :beta,   logo_text: "IB", logo_color: "#dc2626", domain: "interactivebrokers.com" },
+      indexa_capital: { region: "ES",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "IC", logo_color: "#dc2626", domain: "indexacapital.com" },
+      sophtron:       { region: "US",      kinds: %w[Bank Investment], maturity: :alpha,  logo_text: "SO", logo_color: "#0d9488", domain: "sophtron.com" },
+      trading212:     { region: "EU",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "T2", logo_color: "#0d9488", domain: "trading212.com" },
+      trade_republic: { region: "EU",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "TR", logo_color: nil,       domain: "traderepublic.com" },
+      plaid:          { region: "US",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_color: "#4f46e5", domain: "plaid.com", tier: "Paid" },
+      plaid_eu:       { region: "EU",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_color: "#4f46e5", domain: "plaid.com", tier: "Paid", name: "Plaid EU" },
+      questrade:      { region: "CA",      kinds: %w[Investment],      maturity: :beta,   logo_text: "QT", logo_color: "#0d9488", domain: "questrade.com" },
+      redbark:        { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "RB", logo_color: "#b91c1c", domain: "redbark.com" },
+      onchain_wallet: { region: "Global",  kinds: %w[Crypto],          maturity: :alpha,  logo_text: "OC", logo_color: "#d97706", domain: nil, logo_icon: "wallet", name: "On-chain wallets" }
     }.freeze
 
     def self.for(provider_key)
-      REGISTRY[provider_key.to_sym] || { logo_text: provider_key.to_s.first(2).upcase, logo_bg: "bg-gray-500" }
+      REGISTRY[provider_key.to_sym] || { logo_text: provider_key.to_s.first(2).upcase, logo_color: nil }
     end
 
     # Brandfetch icon URL for the provider's own brand, or nil when the provider
@@ -36,11 +36,7 @@ class Provider
     # returning Brandfetch's lettermark, so ProviderLogo keeps its own fallback.
     def self.logo_url(provider_key)
       domain = self.for(provider_key)[:domain]
-      client_id = Setting.brand_fetch_client_id
-      return if domain.blank? || client_id.blank?
-
-      size = Setting.brand_fetch_logo_size
-      "https://cdn.brandfetch.io/#{domain}/icon/fallback/404/w/#{size}/h/#{size}?c=#{client_id}"
+      Setting.brand_fetch_icon_url(domain, fallback: "404")
     end
   end
 end

--- a/app/models/provider/metadata.rb
+++ b/app/models/provider/metadata.rb
@@ -1,34 +1,46 @@
 class Provider
   module Metadata
     REGISTRY = {
-      akahu:          { region: "NZ",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "AK", logo_bg: "bg-emerald-600" },
-      simplefin:      { region: "US",      kinds: %w[Bank Investment], maturity: :stable, logo_text: "SF", logo_bg: "bg-blue-600" },
-      lunchflow:      { region: "Global",  kinds: %w[Bank],            maturity: :stable, logo_text: "LF", logo_bg: "bg-orange-500" },
-      up:             { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "UP", logo_bg: "bg-orange-600" },
-      monobank:       { region: "UA",      kinds: %w[Bank],            maturity: :alpha,  logo_text: "MB", logo_bg: "bg-inverse" },
-      enable_banking: { region: "EU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "EB", logo_bg: "bg-purple-600" },
-      coinstats:      { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CS", logo_bg: "bg-pink-600" },
-      wise:           { region: "Global",  kinds: %w[Bank],            maturity: :beta,   logo_text: "WI", logo_bg: "bg-green-500" },
-      mercury:        { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "ME", logo_bg: "bg-cyan-600" },
-      brex:           { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "BX", logo_bg: "bg-emerald-600" },
-      coinbase:       { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CB", logo_bg: "bg-blue-500" },
-      binance:        { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "BI", logo_bg: "bg-yellow-600" },
-      kraken:         { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "KR", logo_bg: "bg-violet-600" },
-      snaptrade:      { region: "US / CA", kinds: %w[Investment],      maturity: :beta,   logo_text: "ST", logo_bg: "bg-green-600" },
-      ibkr:           { region: "Global",  kinds: %w[Investment],      maturity: :beta,   logo_text: "IB", logo_bg: "bg-red-600" },
-      indexa_capital: { region: "ES",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "IC", logo_bg: "bg-red-600" },
-      sophtron:       { region: "US",      kinds: %w[Bank Investment], maturity: :alpha,  logo_text: "SO", logo_bg: "bg-teal-600" },
-      trading212:     { region: "EU",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "T2", logo_bg: "bg-teal-600" },
-      trade_republic: { region: "EU",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "TR", logo_bg: "bg-primary" },
-      plaid:          { region: "US",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600", tier: "Paid" },
-      plaid_eu:       { region: "EU",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600", tier: "Paid", name: "Plaid EU" },
-      questrade:      { region: "CA",      kinds: %w[Investment],      maturity: :beta,   logo_text: "QT", logo_bg: "bg-teal-600" },
-      redbark:        { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "RB", logo_bg: "bg-red-700" },
-      onchain_wallet: { region: "Global",  kinds: %w[Crypto],          maturity: :alpha,  logo_text: "OC", logo_bg: "bg-amber-600", name: "On-chain wallets" }
+      akahu:          { region: "NZ",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "AK", logo_bg: "bg-emerald-600", domain: "akahu.nz" },
+      simplefin:      { region: "US",      kinds: %w[Bank Investment], maturity: :stable, logo_text: "SF", logo_bg: "bg-blue-600",    domain: "simplefin.org" },
+      lunchflow:      { region: "Global",  kinds: %w[Bank],            maturity: :stable, logo_text: "LF", logo_bg: "bg-orange-500",  domain: "lunchflow.app" },
+      up:             { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "UP", logo_bg: "bg-orange-600",  domain: "up.com.au" },
+      monobank:       { region: "UA",      kinds: %w[Bank],            maturity: :alpha,  logo_text: "MB", logo_bg: "bg-inverse",     domain: "monobank.ua" },
+      enable_banking: { region: "EU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "EB", logo_bg: "bg-purple-600",  domain: "enablebanking.com" },
+      coinstats:      { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CS", logo_bg: "bg-pink-600",    domain: "coinstats.app" },
+      wise:           { region: "Global",  kinds: %w[Bank],            maturity: :beta,   logo_text: "WI", logo_bg: "bg-green-500",   domain: "wise.com" },
+      mercury:        { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "ME", logo_bg: "bg-cyan-600",    domain: "mercury.com" },
+      brex:           { region: "US",      kinds: %w[Bank],            maturity: :beta,   logo_text: "BX", logo_bg: "bg-emerald-600", domain: "brex.com" },
+      coinbase:       { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "CB", logo_bg: "bg-blue-500",    domain: "coinbase.com" },
+      binance:        { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "BI", logo_bg: "bg-yellow-600",  domain: "binance.com" },
+      kraken:         { region: "Global",  kinds: %w[Crypto],          maturity: :beta,   logo_text: "KR", logo_bg: "bg-violet-600",  domain: "kraken.com" },
+      snaptrade:      { region: "US / CA", kinds: %w[Investment],      maturity: :beta,   logo_text: "ST", logo_bg: "bg-green-600",   domain: "snaptrade.com" },
+      ibkr:           { region: "Global",  kinds: %w[Investment],      maturity: :beta,   logo_text: "IB", logo_bg: "bg-red-600",     domain: "interactivebrokers.com" },
+      indexa_capital: { region: "ES",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "IC", logo_bg: "bg-red-600",     domain: "indexacapital.com" },
+      sophtron:       { region: "US",      kinds: %w[Bank Investment], maturity: :alpha,  logo_text: "SO", logo_bg: "bg-teal-600",    domain: "sophtron.com" },
+      trading212:     { region: "EU",      kinds: %w[Investment],      maturity: :alpha,  logo_text: "T2", logo_bg: "bg-teal-600",    domain: "trading212.com" },
+      trade_republic: { region: "EU",      kinds: %w[Bank Investment], maturity: :beta,   logo_text: "TR", logo_bg: "bg-primary",     domain: "traderepublic.com" },
+      plaid:          { region: "US",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600",  domain: "plaid.com", tier: "Paid" },
+      plaid_eu:       { region: "EU",      kinds: %w[Bank],            maturity: :stable, logo_text: "PL", logo_bg: "bg-indigo-600",  domain: "plaid.com", tier: "Paid", name: "Plaid EU" },
+      questrade:      { region: "CA",      kinds: %w[Investment],      maturity: :beta,   logo_text: "QT", logo_bg: "bg-teal-600",    domain: "questrade.com" },
+      redbark:        { region: "AU",      kinds: %w[Bank],            maturity: :beta,   logo_text: "RB", logo_bg: "bg-red-700",     domain: "redbark.com" },
+      onchain_wallet: { region: "Global",  kinds: %w[Crypto],          maturity: :alpha,  logo_text: "OC", logo_bg: "bg-amber-600",   domain: nil, logo_icon: "wallet", name: "On-chain wallets" }
     }.freeze
 
     def self.for(provider_key)
       REGISTRY[provider_key.to_sym] || { logo_text: provider_key.to_s.first(2).upcase, logo_bg: "bg-gray-500" }
+    end
+
+    # Brandfetch icon URL for the provider's own brand, or nil when the provider
+    # has no domain or Brandfetch isn't configured. Unknown brands 404 instead of
+    # returning Brandfetch's lettermark, so ProviderLogo keeps its own fallback.
+    def self.logo_url(provider_key)
+      domain = self.for(provider_key)[:domain]
+      client_id = Setting.brand_fetch_client_id
+      return if domain.blank? || client_id.blank?
+
+      size = Setting.brand_fetch_logo_size
+      "https://cdn.brandfetch.io/#{domain}/icon/fallback/404/w/#{size}/h/#{size}?c=#{client_id}"
     end
   end
 end

--- a/app/models/security.rb
+++ b/app/models/security.rb
@@ -31,9 +31,8 @@ class Security < ApplicationRecord
   def self.brandfetch_crypto_url(base_asset)
     return nil if base_asset.blank?
     return nil unless base_asset.to_s.match?(SAFE_CRYPTO_SYMBOL)
-    return nil unless Setting.brand_fetch_client_id.present?
-    size = Setting.brand_fetch_logo_size
-    "https://cdn.brandfetch.io/crypto/#{base_asset}/icon/fallback/lettermark/w/#{size}/h/#{size}?c=#{Setting.brand_fetch_client_id}"
+
+    Setting.brand_fetch_icon_url(base_asset, namespace: "crypto")
   end
 
   before_validation :upcase_symbols
@@ -142,17 +141,10 @@ class Security < ApplicationRecord
   end
 
   def brandfetch_icon_url(width: nil, height: nil)
-    return nil unless Setting.brand_fetch_client_id.present?
-
-    w = width || Setting.brand_fetch_logo_size
-    h = height || Setting.brand_fetch_logo_size
-
     identifier = extract_domain(website_url) if website_url.present?
     identifier ||= ticker
 
-    return nil unless identifier.present?
-
-    "https://cdn.brandfetch.io/#{identifier}/icon/fallback/lettermark/w/#{w}/h/#{h}?c=#{Setting.brand_fetch_client_id}"
+    Setting.brand_fetch_icon_url(identifier, width: width, height: height)
   end
 
   private

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -56,6 +56,16 @@ class Setting < RailsSettings::Base
     url.gsub(BRAND_FETCH_URL_PATTERN, "\\1w/#{size}/h/#{size}\\2")
   end
 
+  def self.brand_fetch_icon_url(identifier, fallback: "lettermark", namespace: nil, width: nil, height: nil)
+    return nil if identifier.blank? || brand_fetch_client_id.blank?
+
+    w = width || brand_fetch_logo_size
+    h = height || brand_fetch_logo_size
+    path = [ namespace, identifier ].compact_blank.join("/")
+
+    "https://cdn.brandfetch.io/#{path}/icon/fallback/#{fallback}/w/#{w}/h/#{h}?c=#{brand_fetch_client_id}"
+  end
+
   # Provider selection
   field :exchange_rate_provider, type: :string, default: ENV.fetch("EXCHANGE_RATE_PROVIDER", "twelve_data")
   field :securities_provider, type: :string, default: ENV.fetch("SECURITIES_PROVIDER", "twelve_data")

--- a/app/views/akahu_items/_akahu_item.html.erb
+++ b/app/views/akahu_items/_akahu_item.html.erb
@@ -7,9 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-            <p class="text-primary text-xs font-medium"><%= akahu_item.name.to_s.first.to_s.upcase %></p>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :akahu) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/binance_items/_binance_item.html.erb
+++ b/app/views/binance_items/_binance_item.html.erb
@@ -6,11 +6,7 @@
       <div class="flex items-center gap-2">
         <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-        <div class="flex items-center justify-center h-8 w-8 rounded-full" style="background-color: rgba(240, 185, 11, 0.15);">
-          <div class="flex items-center justify-center">
-            <%= icon "coins", size: "sm", class: "text-[#F0B90B]" %>
-          </div>
-        </div>
+        <%= render ProviderLogo.new(provider_key: :binance) %>
 
         <div class="pl-1 text-sm flex-1">
           <div class="flex items-center gap-2">

--- a/app/views/brex_items/_brex_item.html.erb
+++ b/app/views/brex_items/_brex_item.html.erb
@@ -18,15 +18,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
-            <% if brex_item.logo.attached? %>
-              <%= image_tag brex_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p brex_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :brex) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/coinbase_items/_coinbase_item.html.erb
+++ b/app/views/coinbase_items/_coinbase_item.html.erb
@@ -22,11 +22,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 rounded-full" style="background-color: rgba(0, 82, 255, 0.1);">
-            <div class="flex items-center justify-center">
-              <%= icon "bitcoin", size: "sm", class: "text-[#0052FF]" %>
-            </div>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :coinbase) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/coinstats_items/_coinstats_item.html.erb
+++ b/app/views/coinstats_items/_coinstats_item.html.erb
@@ -7,11 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-success/10 rounded-full">
-            <div class="flex items-center justify-center">
-              <%= tag.p coinstats_item.institution_display_name.first.upcase, class: "text-success text-xs font-medium" %>
-            </div>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :coinstats) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/enable_banking_items/_enable_banking_item.html.erb
+++ b/app/views/enable_banking_items/_enable_banking_item.html.erb
@@ -7,15 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-success/10 rounded-full">
-            <% if enable_banking_item.logo.attached? %>
-              <%= image_tag enable_banking_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p enable_banking_item.institution_display_name.first.upcase, class: "text-success text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :enable_banking) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/ibkr_items/_ibkr_item.html.erb
+++ b/app/views/ibkr_items/_ibkr_item.html.erb
@@ -9,9 +9,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 rounded-full bg-[#D32F2F]/10">
-            <span class="text-[#D32F2F] text-xs font-medium">IB</span>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :ibkr) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/indexa_capital_items/_indexa_capital_item.html.erb
+++ b/app/views/indexa_capital_items/_indexa_capital_item.html.erb
@@ -9,11 +9,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
-            <div class="flex items-center justify-center">
-              <%= tag.p indexa_capital_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
-            </div>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :indexa_capital) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/kraken_items/_kraken_item.html.erb
+++ b/app/views/kraken_items/_kraken_item.html.erb
@@ -6,9 +6,7 @@
       <div class="flex items-center gap-2">
         <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-        <div class="flex items-center justify-center h-8 w-8 rounded-full bg-surface-inset">
-          <%= icon "waves", size: "sm", class: "text-primary" %>
-        </div>
+        <%= render ProviderLogo.new(provider_key: :kraken) %>
 
         <div class="pl-1 text-sm flex-1">
           <div class="flex items-center gap-2">

--- a/app/views/lunchflow_items/_lunchflow_item.html.erb
+++ b/app/views/lunchflow_items/_lunchflow_item.html.erb
@@ -7,15 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-orange-600/10 rounded-full">
-            <% if lunchflow_item.logo.attached? %>
-              <%= image_tag lunchflow_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p lunchflow_item.name.first.upcase, class: "text-orange-600 text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :lunchflow) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/mercury_items/_mercury_item.html.erb
+++ b/app/views/mercury_items/_mercury_item.html.erb
@@ -7,15 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-blue-600/10 rounded-full">
-            <% if mercury_item.logo.attached? %>
-              <%= image_tag mercury_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p mercury_item.name.first.upcase, class: "text-blue-600 text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :mercury) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/monobank_items/_monobank_item.html.erb
+++ b/app/views/monobank_items/_monobank_item.html.erb
@@ -7,9 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-            <p class="text-primary text-xs font-medium"><%= monobank_item.name.to_s.first.to_s.upcase %></p>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :monobank) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/onchain_wallet_items/_wallet_card.html.erb
+++ b/app/views/onchain_wallet_items/_wallet_card.html.erb
@@ -7,9 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 rounded-full bg-surface-inset shrink-0">
-            <%= icon "wallet", size: "sm", class: "text-primary" %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :onchain_wallet) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -7,15 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-blue-600/10 rounded-full">
-            <% if plaid_item.logo.attached? %>
-              <%= image_tag plaid_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p plaid_item.name.first.upcase, class: "text-blue-600 text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :plaid) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">
@@ -24,6 +16,7 @@
                 <p class="text-destructive text-sm animate-pulse"><%= t(".deletion_in_progress") %></p>
               <% end %>
             </div>
+            <p class="text-xs text-secondary"><%= t(".provider_name") %></p>
             <% if plaid_item.syncing? %>
               <div class="text-secondary flex items-center gap-1">
                 <%= icon "loader", size: "sm", class: "animate-pulse" %>

--- a/app/views/questrade_items/_questrade_item.html.erb
+++ b/app/views/questrade_items/_questrade_item.html.erb
@@ -7,13 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-            <% if questrade_item.logo.attached? %>
-              <%= image_tag questrade_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <%= tag.p "Q", class: "text-primary text-xs font-medium" %>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :questrade) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/redbark_items/_redbark_item.html.erb
+++ b/app/views/redbark_items/_redbark_item.html.erb
@@ -7,11 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-primary/10 rounded-full">
-            <div class="flex items-center justify-center">
-              <%= tag.p redbark_item.name.first.upcase, class: "text-primary text-xs font-medium" %>
-            </div>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :redbark) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/settings/providers/_akahu_panel.html.erb
+++ b/app/views/settings/providers/_akahu_panel.html.erb
@@ -20,9 +20,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-                  <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :akahu) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/_binance_panel.html.erb
+++ b/app/views/settings/providers/_binance_panel.html.erb
@@ -39,9 +39,7 @@
       <% items.each do |item| %>
         <div class="flex items-center justify-between p-3 bg-container-inset rounded-lg border border-primary">
           <div class="flex items-center gap-3">
-            <div class="w-10 h-10 rounded-full flex items-center justify-center" style="background-color: rgba(240, 185, 11, 0.15);">
-              <%= icon "coins", size: "md", class: "text-[#F0B90B]" %>
-            </div>
+            <%= render ProviderLogo.new(provider_key: :binance, class_name: "w-10 h-10 rounded-full") %>
             <div>
               <p class="font-medium text-primary"><%= item.name %></p>
               <p class="text-xs text-secondary">

--- a/app/views/settings/providers/_brex_panel.html.erb
+++ b/app/views/settings/providers/_brex_panel.html.erb
@@ -30,9 +30,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
-                  <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :brex) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/_coinbase_panel.html.erb
+++ b/app/views/settings/providers/_coinbase_panel.html.erb
@@ -18,9 +18,7 @@
       <% items.each do |item| %>
         <div class="flex items-center justify-between p-3 bg-container-inset rounded-lg border border-primary">
           <div class="flex items-center gap-3">
-            <div class="w-10 h-10 rounded-full bg-[#0052FF] flex items-center justify-center">
-              <%= icon "bitcoin", size: "md", class: "text-white" %>
-            </div>
+            <%= render ProviderLogo.new(provider_key: :coinbase, class_name: "w-10 h-10 rounded-full") %>
             <div>
               <p class="font-medium text-primary"><%= item.name %></p>
               <p class="text-xs text-secondary">

--- a/app/views/settings/providers/_connection_row.html.erb
+++ b/app/views/settings/providers/_connection_row.html.erb
@@ -22,6 +22,7 @@
       <%= icon "chevron-right", size: "sm", class: "!w-3.5 !h-3.5 text-secondary group-open:rotate-90 transition-transform" %>
       <div class="flex items-center flex-wrap gap-2 min-w-0 flex-1">
         <div class="flex items-center gap-2 shrink-0 flex-1">
+          <%= render ProviderLogo.new(provider_key: entry[:provider_key], class_name: "w-7 h-7 rounded-lg") %>
           <h3 class="text-sm font-medium text-primary"><%= entry[:title] %></h3>
           <%= render "settings/providers/maturity_badge", label: maturity_lbl %>
         </div>

--- a/app/views/settings/providers/_drawer_header.html.erb
+++ b/app/views/settings/providers/_drawer_header.html.erb
@@ -3,10 +3,8 @@
 <% maturity_label = meta ? Settings::ProviderCard.maturity_label(meta[:maturity]) : nil %>
 <div class="flex items-center justify-between gap-2">
   <div class="flex items-center gap-2 min-w-0">
-    <% if meta && meta[:logo_bg].present? %>
-      <span class="w-7 h-7 rounded-lg flex items-center justify-center shrink-0 <%= meta[:logo_bg] %>">
-        <span class="text-xs font-bold text-inverse"><%= meta[:logo_text] %></span>
-      </span>
+    <% if meta %>
+      <%= render ProviderLogo.new(provider_key: provider_key, class_name: "w-7 h-7 rounded-lg") %>
     <% end %>
     <h2 class="text-lg font-medium text-primary truncate"><%= title %></h2>
     <%= render "settings/providers/maturity_badge", label: maturity_label %>

--- a/app/views/settings/providers/_kraken_panel.html.erb
+++ b/app/views/settings/providers/_kraken_panel.html.erb
@@ -28,9 +28,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-3 w-full">
               <div class="flex items-center gap-3 min-w-0">
-                <div class="flex items-center justify-center h-8 w-8 rounded-full bg-surface-inset">
-                  <%= icon "waves", size: "sm", class: "text-primary" %>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :kraken) %>
                 <div class="min-w-0">
                   <p class="font-medium text-primary truncate"><%= item.name %></p>
                   <p class="text-xs text-secondary">

--- a/app/views/settings/providers/_mercury_panel.html.erb
+++ b/app/views/settings/providers/_mercury_panel.html.erb
@@ -23,9 +23,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-                  <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :mercury) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/_monobank_panel.html.erb
+++ b/app/views/settings/providers/_monobank_panel.html.erb
@@ -22,9 +22,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-                  <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :monobank) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/_up_panel.html.erb
+++ b/app/views/settings/providers/_up_panel.html.erb
@@ -20,9 +20,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-                  <p class="text-primary text-xs font-medium"><%= item.name.to_s.first.to_s.upcase %></p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :up) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/_wise_panel.html.erb
+++ b/app/views/settings/providers/_wise_panel.html.erb
@@ -25,9 +25,7 @@
           <% disclosure.with_summary_content do %>
             <div class="flex items-center justify-between gap-2 w-full">
               <div class="flex items-center gap-3">
-                <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
-                  <p class="text-primary text-xs font-medium">WI</p>
-                </div>
+                <%= render ProviderLogo.new(provider_key: :wise) %>
                 <div>
                   <p class="font-medium text-primary"><%= item.name %></p>
                   <p class="text-xs text-secondary"><%= item.sync_status_summary %></p>

--- a/app/views/settings/providers/show.html.erb
+++ b/app/views/settings/providers/show.html.erb
@@ -80,9 +80,7 @@
                   region:       meta[:region],
                   kinds:        meta[:kinds],
                   tier:         meta[:tier],
-                  maturity:     meta[:maturity] || :stable,
-                  logo_bg:      meta[:logo_bg],
-                  logo_text:    meta[:logo_text]
+                  maturity:     meta[:maturity] || :stable
                 ) %>
           <% end %>
         </div>

--- a/app/views/simplefin_items/_simplefin_item.html.erb
+++ b/app/views/simplefin_items/_simplefin_item.html.erb
@@ -24,15 +24,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-success/10 rounded-full">
-            <% if simplefin_item.logo.attached? %>
-              <%= image_tag simplefin_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p simplefin_item.name.first.upcase, class: "text-success text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :simplefin) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/snaptrade_items/_snaptrade_item.html.erb
+++ b/app/views/snaptrade_items/_snaptrade_item.html.erb
@@ -13,15 +13,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-success/10 rounded-full">
-            <% if snaptrade_item.logo.attached? %>
-              <%= image_tag snaptrade_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p snaptrade_item.name.first.upcase, class: "text-success text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :snaptrade) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/sophtron_items/_sophtron_item.html.erb
+++ b/app/views/sophtron_items/_sophtron_item.html.erb
@@ -10,15 +10,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-orange-600/10 rounded-full">
-            <% if sophtron_item.logo.attached? %>
-              <%= image_tag sophtron_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
-            <% else %>
-              <div class="flex items-center justify-center">
-                <%= tag.p provider_display_name.first.upcase, class: "text-orange-600 text-xs font-medium" %>
-              </div>
-            <% end %>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :sophtron) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/trade_republic_items/_trade_republic_item.html.erb
+++ b/app/views/trade_republic_items/_trade_republic_item.html.erb
@@ -9,9 +9,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 rounded-full bg-surface-inset">
-            <span class="text-primary text-xs font-medium">TR</span>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :trade_republic) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/trading212_items/_trading212_item.html.erb
+++ b/app/views/trading212_items/_trading212_item.html.erb
@@ -9,9 +9,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 rounded-full bg-teal-600/10">
-            <span class="text-teal-600 text-xs font-medium">T2</span>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :trading212) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/up_items/_up_item.html.erb
+++ b/app/views/up_items/_up_item.html.erb
@@ -7,9 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-surface rounded-full">
-            <p class="text-primary text-xs font-medium"><%= up_item.name.to_s.first.to_s.upcase %></p>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :up) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/app/views/wise_items/_wise_item.html.erb
+++ b/app/views/wise_items/_wise_item.html.erb
@@ -7,9 +7,7 @@
         <div class="flex items-center gap-2">
           <%= icon "chevron-right", class: "group-open:rotate-90 motion-safe:transition-transform motion-safe:duration-150" %>
 
-          <div class="flex items-center justify-center h-8 w-8 bg-container-inset rounded-full">
-            <p class="text-primary text-xs font-bold">WI</p>
-          </div>
+          <%= render ProviderLogo.new(provider_key: :wise) %>
 
           <div class="pl-1 text-sm">
             <div class="flex items-center gap-2">

--- a/config/locales/views/plaid_items/en.yml
+++ b/config/locales/views/plaid_items/en.yml
@@ -25,6 +25,7 @@ en:
       no_accounts_description: We could not load any accounts from this financial
         institution.
       no_accounts_title: No accounts found
+      provider_name: Plaid
       requires_update: Reconnect
       status: Last synced %{timestamp} ago
       status_never: Requires data sync

--- a/test/components/DS/filled_icon_test.rb
+++ b/test/components/DS/filled_icon_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class DS::FilledIconTest < ViewComponent::TestCase
+  test "text fallback renders one letter by default" do
+    render_inline(DS::FilledIcon.new(text: "Example"))
+
+    assert_text "E"
+    assert_no_text "Ex"
+  end
+
+  test "text fallback can render multiple initials when requested" do
+    render_inline(DS::FilledIcon.new(text: "EX", text_length: 2))
+
+    assert_text "EX"
+  end
+
+  test "accepts extra container classes" do
+    render_inline(DS::FilledIcon.new(text: "EX", text_length: 2, class_name: "w-full h-full"))
+
+    assert_selector ".w-full.h-full", text: "EX"
+  end
+end

--- a/test/components/provider_logo_test.rb
+++ b/test/components/provider_logo_test.rb
@@ -7,58 +7,58 @@ class ProviderLogoTest < ViewComponent::TestCase
   end
 
   test "lays the brand icon over the fallback when the provider has a domain" do
-    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example))
 
     assert_selector "img[src='https://cdn.brandfetch.io/example.com/icon/fallback/404/w/40/h/40?c=test-client-id']"
     assert_selector "img[onerror='#{ProviderLogo::REMOVE_ON_ERROR}']"
-    assert_selector "span.bg-gray-500 + img"
+    assert_selector "span[aria-hidden='true'] + img"
   end
 
   test "renders only the fallback when the provider has no domain" do
-    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example))
 
     assert_no_selector "img"
-    assert_selector "span.bg-gray-500 svg"
+    assert_selector "[aria-hidden='true'] svg"
   end
 
   test "renders only the fallback when Brandfetch is not configured" do
     Setting.stubs(:brand_fetch_client_id).returns(nil)
-    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example))
 
     assert_no_selector "img"
-    assert_selector "span.bg-gray-500 svg"
+    assert_selector "[aria-hidden='true'] svg"
   end
 
   test "prefers the icon over the initials in the fallback" do
-    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example))
 
-    assert_selector "span.bg-gray-500 svg"
+    assert_selector "[aria-hidden='true'] svg"
     assert_no_text "EX"
   end
 
   test "falls back to the initials when there is no icon" do
-    stub_metadata(logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example))
 
     assert_no_selector "svg"
-    assert_selector "span.bg-gray-500", text: "EX"
+    assert_selector "[aria-hidden='true']", text: "EX"
   end
 
   test "applies the size and shape classes to the container" do
-    stub_metadata(domain: "example.com", logo_text: "EX", logo_bg: "bg-gray-500")
+    stub_metadata(domain: "example.com", logo_text: "EX", logo_color: "#6b7280")
 
     render_inline(ProviderLogo.new(provider_key: :example, class_name: "w-9 h-9 rounded-lg"))
 
-    assert_selector "span.w-9.h-9.rounded-lg > span.bg-gray-500"
+    assert_selector "span.w-9.h-9.rounded-lg > span[aria-hidden='true']"
     assert_selector "span.w-9.h-9.rounded-lg > img"
   end
 

--- a/test/components/provider_logo_test.rb
+++ b/test/components/provider_logo_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class ProviderLogoTest < ViewComponent::TestCase
+  setup do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+    Setting.stubs(:brand_fetch_logo_size).returns(40)
+  end
+
+  test "lays the brand icon over the fallback when the provider has a domain" do
+    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example))
+
+    assert_selector "img[src='https://cdn.brandfetch.io/example.com/icon/fallback/404/w/40/h/40?c=test-client-id']"
+    assert_selector "img[onerror='#{ProviderLogo::REMOVE_ON_ERROR}']"
+    assert_selector "span.bg-gray-500 + img"
+  end
+
+  test "renders only the fallback when the provider has no domain" do
+    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example))
+
+    assert_no_selector "img"
+    assert_selector "span.bg-gray-500 svg"
+  end
+
+  test "renders only the fallback when Brandfetch is not configured" do
+    Setting.stubs(:brand_fetch_client_id).returns(nil)
+    stub_metadata(domain: "example.com", logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example))
+
+    assert_no_selector "img"
+    assert_selector "span.bg-gray-500 svg"
+  end
+
+  test "prefers the icon over the initials in the fallback" do
+    stub_metadata(logo_icon: "wallet", logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example))
+
+    assert_selector "span.bg-gray-500 svg"
+    assert_no_text "EX"
+  end
+
+  test "falls back to the initials when there is no icon" do
+    stub_metadata(logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example))
+
+    assert_no_selector "svg"
+    assert_selector "span.bg-gray-500", text: "EX"
+  end
+
+  test "applies the size and shape classes to the container" do
+    stub_metadata(domain: "example.com", logo_text: "EX", logo_bg: "bg-gray-500")
+
+    render_inline(ProviderLogo.new(provider_key: :example, class_name: "w-9 h-9 rounded-lg"))
+
+    assert_selector "span.w-9.h-9.rounded-lg > span.bg-gray-500"
+    assert_selector "span.w-9.h-9.rounded-lg > img"
+  end
+
+  private
+    def stub_metadata(**metadata)
+      Provider::Metadata.stubs(:for).with(:example).returns(metadata)
+    end
+end

--- a/test/models/provider/metadata_test.rb
+++ b/test/models/provider/metadata_test.rb
@@ -17,4 +17,25 @@ class Provider::MetadataTest < ActiveSupport::TestCase
       refute metadata.key?(:kind)
     end
   end
+
+  test "logo_url builds a Brandfetch URL from the provider domain" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+    Setting.stubs(:brand_fetch_logo_size).returns(40)
+
+    assert_equal "https://cdn.brandfetch.io/wise.com/icon/fallback/404/w/40/h/40?c=test-client-id",
+                 Provider::Metadata.logo_url(:wise)
+  end
+
+  test "logo_url is nil when Brandfetch is not configured" do
+    Setting.stubs(:brand_fetch_client_id).returns(nil)
+
+    assert_nil Provider::Metadata.logo_url(:wise)
+  end
+
+  test "logo_url is nil for providers without a domain" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+
+    assert_nil Provider::Metadata.logo_url(:onchain_wallet)
+    assert_nil Provider::Metadata.logo_url(:unknown_provider)
+  end
 end

--- a/test/models/provider/metadata_test.rb
+++ b/test/models/provider/metadata_test.rb
@@ -18,6 +18,13 @@ class Provider::MetadataTest < ActiveSupport::TestCase
     end
   end
 
+  test "registered provider metadata keeps fallback colors out of raw tailwind classes" do
+    Provider::Metadata::REGISTRY.each_value do |metadata|
+      refute metadata.key?(:logo_bg)
+      assert_match(/\A#[0-9a-f]{6}\z/i, metadata[:logo_color]) if metadata[:logo_color].present?
+    end
+  end
+
   test "logo_url builds a Brandfetch URL from the provider domain" do
     Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
     Setting.stubs(:brand_fetch_logo_size).returns(40)

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -132,6 +132,34 @@ class SettingTest < ActiveSupport::TestCase
     assert_equal "test-model", Setting.openai_model
   end
 
+  test "brand_fetch_icon_url builds a logo URL with the requested fallback" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+    Setting.stubs(:brand_fetch_logo_size).returns(40)
+
+    assert_equal(
+      "https://cdn.brandfetch.io/example.com/icon/fallback/404/w/40/h/40?c=test-client-id",
+      Setting.brand_fetch_icon_url("example.com", fallback: "404")
+    )
+  end
+
+  test "brand_fetch_icon_url supports namespaced routes and explicit dimensions" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+    Setting.stubs(:brand_fetch_logo_size).returns(40)
+
+    assert_equal(
+      "https://cdn.brandfetch.io/crypto/BTC/icon/fallback/lettermark/w/80/h/80?c=test-client-id",
+      Setting.brand_fetch_icon_url("BTC", namespace: "crypto", width: 80, height: 80)
+    )
+  end
+
+  test "brand_fetch_icon_url returns nil without an identifier or client id" do
+    Setting.stubs(:brand_fetch_client_id).returns("test-client-id")
+    assert_nil Setting.brand_fetch_icon_url(nil)
+
+    Setting.stubs(:brand_fetch_client_id).returns(nil)
+    assert_nil Setting.brand_fetch_icon_url("example.com")
+  end
+
   test "enabled_securities_providers falls back to twelve_data when nothing is configured" do
     with_env_overrides("SECURITIES_PROVIDERS" => nil, "SECURITIES_PROVIDER" => nil) do
       assert_equal [ "twelve_data" ], Setting.enabled_securities_providers


### PR DESCRIPTION
## Problems

- Bank Sync settings and the Accounts page identified sync providers with initials or hand-built badges.
- Each view built its own badge, so the same provider looked different from place to place.
- Once a provider was connected, its card left the "Available" list, and connection rows showed no icon at all.
- Brandfetch was already used for merchant, institution and security logos, but not for providers.

## What changed

- **Provider domains.** Each provider in `Provider::Metadata` now has a hardcoded brand `domain`. On-chain wallets have none, because they span many chains rather than one company, so they use a generic `logo_icon` (`wallet`) instead.
- **`ProviderLogo` component.** A single component renders every provider logo, falling back in this order:
  1. The provider's Brandfetch icon (needs a domain and a configured Brandfetch client ID)
  2. The provider's `logo_icon`
  3. The provider's `logo_text` initials on its `logo_bg` colour
- **Where it's used:**
  - Bank Sync: "Available" provider cards, the setup drawer header, "Your connections" rows (these had no icon before) and connection rows inside provider panels
  - Accounts: every provider connection card, including the separate on-chain wallet card
- **Plaid label.** Plaid creates one connection per bank, and its card is titled with the bank's name ("Chase"). The card now shows "Plaid" underneath in small grey text, as seven other providers already do (`t(".provider_name")`).

## How the fallback works

The logo URL asks Brandfetch for `fallback/404`, so Brandfetch returns a 404 for brands it doesn't know instead of its generic letter icon. Our fallback is always rendered, and the Brandfetch image sits on top of it with an opaque background. If the image fails, an inline `onerror="this.remove()"` removes it and our fallback shows through.

## Provider logos vs institution logos

Provider logos only appear where the thing shown is a provider. Institution logos stay on accounts, which still use `Account#logo_url`.

The item partials used to prefer an attached `item.logo` (`has_one_attached :logo`). Those branches are removed. No code, in any version of the repository, has ever called `logo.attach` on a provider item. The attachment was declared in the original Plaid integration and copied into each new provider after that, but nothing ever filled it. So no install loses a stored logo.

## Notes

- **Missing brands.** Brandfetch has no icon for SnapTrade, Sophtron or Redbark. I have requested updates at https://brandfetch.com/update . Once Brandfetch adds them, they will appear in Sure.
- **Without Brandfetch configured**, Accounts cards now show the provider's badge from the registry. Before, each partial used its own tinted background and the first letter of the connection or bank name ("C" for a Chase connection through Plaid). Raw hex brand colours on the Binance, Coinbase and IBKR cards are gone.

## Screenshots

| Before | After |
|---|---|
| <img width="1098" height="907" alt="image" src="https://github.com/user-attachments/assets/b60f91cf-02f4-40a3-a010-b86affffe8dd" /> | <img width="1068" height="917" alt="image" src="https://github.com/user-attachments/assets/eca95aaf-a7d0-4b91-8184-0cabdcee3167" /> |
| <img width="695" height="902" alt="image" src="https://github.com/user-attachments/assets/829e2d5f-3e8c-42be-989a-8a8cdd2775d5" /> | <img width="705" height="880" alt="image" src="https://github.com/user-attachments/assets/5f97291e-3182-4a5b-9442-bc58b171b692" /> |
| <img width="1050" height="912" alt="image" src="https://github.com/user-attachments/assets/4f3f5f7f-50cd-41f9-a45b-d920c0fbbd07" /> | <img width="1072" height="902" alt="image" src="https://github.com/user-attachments/assets/e549c46c-8748-4cc8-baf8-445f3fa0a337" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent provider logos across connection cards, provider settings, and item summaries.
  - Logos can display branded images with icon, initials, or text fallbacks when needed.
  - Added a provider name caption to Plaid item summaries.
  - Expanded logo coverage for providers previously shown with generic or text-based badges.

- **Bug Fixes**
  - Improved logo fallback behavior when branded images are unavailable or fail to load.
  - Standardized logo sizing, shape, and appearance across supported provider views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->