### PR TITLE
fix(i18n): use the official Brandfetch name in settings and docs

### DIFF
--- a/config/locales/views/settings/hostings/ca.yml
+++ b/config/locales/views/settings/hostings/ca.yml
@@ -58,8 +58,8 @@ ca:
         url_placeholder: https://your-agent-host/v1/chat
       brand_fetch_settings:
         description: Introdueix el Client ID proporcionat per Brandfetch
-        env_configured_message: Has configurat correctament el teu Client ID de Brand
-          Fetch mitjançant la variable d'entorn BRAND_FETCH_CLIENT_ID.
+        env_configured_message: Has configurat correctament el teu Client ID de Brandfetch
+          mitjançant la variable d'entorn BRAND_FETCH_CLIENT_ID.
         high_res_description: Quan està activat, els logotips es recuperaran amb resolució
           120×120 en lloc de 40×40. Això proporciona imatges més nítides en pantalles
           d'alta densitat.

--- a/config/locales/views/settings/hostings/ca.yml
+++ b/config/locales/views/settings/hostings/ca.yml
@@ -57,7 +57,7 @@ ca:
         url_label: URL de l'endpoint
         url_placeholder: https://your-agent-host/v1/chat
       brand_fetch_settings:
-        description: Introdueix el Client ID proporcionat per Brand Fetch
+        description: Introdueix el Client ID proporcionat per Brandfetch
         env_configured_message: Has configurat correctament el teu Client ID de Brand
           Fetch mitjançant la variable d'entorn BRAND_FETCH_CLIENT_ID.
         high_res_description: Quan està activat, els logotips es recuperaran amb resolució
@@ -68,13 +68,13 @@ ca:
         placeholder: Introdueix aquí el teu Client ID
         setup_step_1_html: Visita <a href="https://brandfetch.com/developers" target="_blank"
           rel="noopener noreferrer" class="underline">brandfetch.com</a> i crea un
-          compte de desenvolupador gratuït de Brand Fetch.
+          compte de desenvolupador gratuït de Brandfetch.
         setup_step_2_html: Ves a la pàgina <a href="https://developers.brandfetch.com/dashboard/logo-api"
           target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.
         setup_step_3: Toca la icona de l'ull a la secció "Your Client ID" per revelar
           el teu Client ID i enganxa'l a sota.
         show_details: "(mostra detalls)"
-        title: Configuració de Brand Fetch
+        title: Configuració de Brandfetch
       clear_cache:
         cache_cleared: La memòria cau de dades s'ha netejat. Pot trigar uns instants
           a completar-se.

--- a/config/locales/views/settings/hostings/de.yml
+++ b/config/locales/views/settings/hostings/de.yml
@@ -67,7 +67,7 @@ de:
         title: Brandfetch Einstellungen
         high_res_label: Hochauflösende Logos aktivieren
         high_res_description: Wenn aktiviert, werden Logos in 120x120 statt 40x40 abgerufen. Das liefert schärfere Bilder auf hochauflösenden Displays.
-        env_configured_message: Deine Brand-Fetch-Client-ID ist über die Umgebungsvariable BRAND_FETCH_CLIENT_ID eingerichtet.
+        env_configured_message: Deine Brandfetch-Client-ID ist über die Umgebungsvariable BRAND_FETCH_CLIENT_ID eingerichtet.
         setup_step_1_html: Öffne <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> und leg dir ein kostenloses Entwicklerkonto an.
         setup_step_2_html: Geh auf die Seite <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.
         setup_step_3: Klick auf das Auge-Symbol unter „Your Client ID“, um die ID sichtbar zu machen, und füg sie unten ein.

--- a/config/locales/views/settings/hostings/de.yml
+++ b/config/locales/views/settings/hostings/de.yml
@@ -61,10 +61,10 @@ de:
         twelve_data_hint: braucht API-Key, 800 Credits/Tag
         yahoo_finance_hint: kostenlos, ohne API-Key
       brand_fetch_settings:
-        description: Gib die von Brand Fetch bereitgestellte Client-ID ein.
+        description: Gib die von Brandfetch bereitgestellte Client-ID ein.
         label: Client-ID
         placeholder: Gib hier deine Client-ID ein
-        title: Brand Fetch Einstellungen
+        title: Brandfetch Einstellungen
         high_res_label: Hochauflösende Logos aktivieren
         high_res_description: Wenn aktiviert, werden Logos in 120x120 statt 40x40 abgerufen. Das liefert schärfere Bilder auf hochauflösenden Displays.
         env_configured_message: Deine Brand-Fetch-Client-ID ist über die Umgebungsvariable BRAND_FETCH_CLIENT_ID eingerichtet.

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -85,15 +85,15 @@ en:
           title: Disconnect external assistant?
           body: This will remove the saved URL, token, and agent ID, and switch to the builtin assistant. You can reconnect later by entering new credentials.
       brand_fetch_settings:
-        description: Enter the Client ID provided by Brand Fetch
-        env_configured_message: You have successfully configured your Brand Fetch Client ID through the BRAND_FETCH_CLIENT_ID environment variable.
+        description: Enter the Client ID provided by Brandfetch
+        env_configured_message: You have successfully configured your Brandfetch Client ID through the BRAND_FETCH_CLIENT_ID environment variable.
         show_details: "(show details)"
-        setup_step_1_html: 'Visit <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> and create a free Brand Fetch Developer account.'
+        setup_step_1_html: 'Visit <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> and create a free Brandfetch Developer account.'
         setup_step_2_html: 'Go to the <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a> page.'
         setup_step_3: 'Tap the eye icon under the "Your Client ID" section to reveal your Client ID and paste it below.'
         label: Client ID
         placeholder: Enter your Client ID here
-        title: Brand Fetch Settings
+        title: Brandfetch Settings
         high_res_label: Enable high-resolution logos
         high_res_description: When enabled, logos will be retrieved at 120x120 resolution instead of 40x40. This provides sharper images on high-DPI displays.
       llm_provider_selector:

--- a/config/locales/views/settings/hostings/es.yml
+++ b/config/locales/views/settings/hostings/es.yml
@@ -87,15 +87,15 @@ es:
           title: ¿Desconectar asistente externo?
           body: Esto eliminará la URL guardada, el token y el ID del agente, y cambiará al asistente integrado. Podrás volver a conectarlo más tarde introduciendo nuevas credenciales.
       brand_fetch_settings:
-        description: Introduce el ID de Cliente proporcionado por Brand Fetch
-        env_configured_message: Has configurado correctamente tu Client ID de Brand Fetch mediante la variable de entorno BRAND_FETCH_CLIENT_ID.
+        description: Introduce el ID de Cliente proporcionado por Brandfetch
+        env_configured_message: Has configurado correctamente tu Client ID de Brandfetch mediante la variable de entorno BRAND_FETCH_CLIENT_ID.
         show_details: (ver detalles)
-        setup_step_1_html: Visita <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> y crea una cuenta gratuita de desarrollador de Brand Fetch.
+        setup_step_1_html: Visita <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> y crea una cuenta gratuita de desarrollador de Brandfetch.
         setup_step_2_html: Ve a la página <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.
         setup_step_3: Pulsa el icono del ojo en la sección "Your Client ID" para revelar tu Client ID y pégalo abajo.
         label: ID de Cliente
         placeholder: Introduce tu ID de Cliente aquí
-        title: Configuración de Brand Fetch
+        title: Configuración de Brandfetch
         high_res_label: Activar logotipos de alta resolución
         high_res_description: Cuando está habilitado, los logotipos se obtendrán a una resolución de 120x120 en lugar de 40x40. Esto ofrece imágenes más nítidas en pantallas de alta densidad de píxeles (DPI).
       llm_provider_selector:

--- a/config/locales/views/settings/hostings/fr.yml
+++ b/config/locales/views/settings/hostings/fr.yml
@@ -51,17 +51,17 @@ fr:
         url_label: URL du endpoint
         url_placeholder: https://your-agent-host/v1/chat
       brand_fetch_settings:
-        description: Saisissez l'ID client fourni par Brand Fetch
-        env_configured_message: Vous avez configuré avec succès votre ID client Brand Fetch via la variable d'environnement BRAND_FETCH_CLIENT_ID.
+        description: Saisissez l'ID client fourni par Brandfetch
+        env_configured_message: Vous avez configuré avec succès votre ID client Brandfetch via la variable d'environnement BRAND_FETCH_CLIENT_ID.
         high_res_description: Lorsque cette option est activée, les logos seront récupérés en résolution 120x120 au lieu de 40x40. Cela offre des images plus nettes sur les écrans à haute densité de pixels.
         high_res_label: Activer les logos haute résolution
         label: ID client
         placeholder: Entrez votre ID client ici
-        setup_step_1_html: Visitez <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> et créez un compte de développeur Brand Fetch gratuit.
+        setup_step_1_html: Visitez <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> et créez un compte de développeur Brandfetch gratuit.
         setup_step_2_html: Accédez à la page <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">API du logo</a>.
         setup_step_3: Appuyez sur l'icône en forme d'œil sous la section « Votre ID client » pour révéler votre ID client et collez-le ci-dessous.
         show_details: "(afficher les détails)"
-        title: Paramètres Brand Fetch
+        title: Paramètres Brandfetch
       clear_cache:
         cache_cleared: Le cache de données a été effacé. Cela peut prendre quelques instants.
       disconnect_external_assistant:

--- a/config/locales/views/settings/hostings/hu.yml
+++ b/config/locales/views/settings/hostings/hu.yml
@@ -81,15 +81,15 @@ hu:
           title: Bontod a külső asszisztens kapcsolatát?
           body: Ez eltávolítja a mentett URL-t, tokent és ügynökazonosítót, és visszavált a beépített asszisztensre. Később újra csatlakozhatsz új hitelesítő adatok megadásával.
       brand_fetch_settings:
-        description: Add meg a Brand Fetch által biztosított kliens-azonosítót
-        env_configured_message: Sikeresen konfiguráltad a Brand Fetch kliens-azonosítódat a BRAND_FETCH_CLIENT_ID környezeti változón keresztül.
+        description: Add meg a Brandfetch által biztosított kliens-azonosítót
+        env_configured_message: Sikeresen konfiguráltad a Brandfetch kliens-azonosítódat a BRAND_FETCH_CLIENT_ID környezeti változón keresztül.
         show_details: "(részletek megjelenítése)"
-        setup_step_1_html: 'Látogass el a <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> oldalra, és hozz létre egy ingyenes Brand Fetch fejlesztői fiókot.'
+        setup_step_1_html: 'Látogass el a <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> oldalra, és hozz létre egy ingyenes Brandfetch fejlesztői fiókot.'
         setup_step_2_html: 'Menj a <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a> oldalra.'
         setup_step_3: 'Kattints a szem ikonra a „Your Client ID" rész alatt, hogy megjelenítsd a kliens-azonosítódat, majd illeszd be alább.'
         label: Kliens-azonosító
         placeholder: Add meg ide a kliens-azonosítódat
-        title: Brand Fetch beállítások
+        title: Brandfetch beállítások
         high_res_label: Nagy felbontású logók engedélyezése
         high_res_description: Ha engedélyezve van, a logók 120x120 felbontásban kerülnek lekérésre 40x40 helyett. Ez élesebb képeket biztosít nagy felbontású kijelzőkön.
       openai_settings:

--- a/config/locales/views/settings/hostings/it.yml
+++ b/config/locales/views/settings/hostings/it.yml
@@ -82,15 +82,15 @@ it:
           title: Disconnettere l'assistente esterno?
           body: Questo rimuoverà l'URL, il token e l'ID agente salvati, e passerà all'assistente integrato. Puoi riconnetterti in seguito inserendo nuove credenziali.
       brand_fetch_settings:
-        description: Inserisci il Client ID fornito da Brand Fetch
-        env_configured_message: Hai configurato con successo il tuo Client ID di Brand Fetch tramite la variabile d'ambiente BRAND_FETCH_CLIENT_ID.
+        description: Inserisci il Client ID fornito da Brandfetch
+        env_configured_message: Hai configurato con successo il tuo Client ID di Brandfetch tramite la variabile d'ambiente BRAND_FETCH_CLIENT_ID.
         show_details: "(mostra dettagli)"
-        setup_step_1_html: 'Visita <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> e crea un account sviluppatore Brand Fetch gratuito.'
+        setup_step_1_html: 'Visita <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> e crea un account sviluppatore Brandfetch gratuito.'
         setup_step_2_html: 'Vai alla pagina <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.'
         setup_step_3: 'Tocca l''icona occhio nella sezione "Il tuo Client ID" per visualizzare il tuo Client ID e incollarlo qui sotto.'
         label: Client ID
         placeholder: Inserisci il tuo Client ID qui
-        title: Impostazioni Brand Fetch
+        title: Impostazioni Brandfetch
         high_res_label: Abilita loghi ad alta risoluzione
         high_res_description: Se abilitato, i loghi verranno recuperati alla risoluzione 120x120 invece di 40x40. Questo fornisce immagini più nitide su display ad alta densità.
       llm_provider_selector:

--- a/config/locales/views/settings/hostings/nl.yml
+++ b/config/locales/views/settings/hostings/nl.yml
@@ -35,10 +35,10 @@ nl:
           twelve_data: Twelve Data
           yahoo_finance: Yahoo Finance
       brand_fetch_settings:
-        description: Voer het Client ID in dat door Brand Fetch is verstrekt
+        description: Voer het Client ID in dat door Brandfetch is verstrekt
         label: Client ID
         placeholder: Voer hier uw Client ID in
-        title: Brand Fetch instellingen
+        title: Brandfetch instellingen
       openai_settings:
         description: Voer het toegangstoken in en configureer optioneel een aangepaste OpenAI-compatibele provider
         env_configured_message: Succesvol geconfigureerd via omgevingsvariabelen.

--- a/config/locales/views/settings/hostings/pl.yml
+++ b/config/locales/views/settings/hostings/pl.yml
@@ -65,10 +65,10 @@ pl:
           title: Rozłączyć zewnętrznego asystenta?
           body: To usunie zapisany URL, token i ID agenta oraz przełączy na asystenta wbudowanego. Możesz połączyć ponownie później, podając nowe dane.
       brand_fetch_settings:
-        description: Wprowadź Client ID otrzymany od Brand Fetch
+        description: Wprowadź Client ID otrzymany od Brandfetch
         label: Client ID
         placeholder: Wprowadź tutaj swój Client ID
-        title: Ustawienia Brand Fetch
+        title: Ustawienia Brandfetch
         high_res_label: Włącz logotypy o wysokiej rozdzielczości
         high_res_description: Gdy włączone, logotypy będą pobierane w rozdzielczości 120x120 zamiast 40x40. Zapewnia to ostrzejsze obrazy na ekranach o wysokim DPI.
       openai_settings:

--- a/config/locales/views/settings/hostings/pt-BR.yml
+++ b/config/locales/views/settings/hostings/pt-BR.yml
@@ -35,10 +35,10 @@ pt-BR:
           twelve_data: Twelve Data
           yahoo_finance: Yahoo Finance
       brand_fetch_settings:
-        description: Insira o Client ID fornecido pelo Brand Fetch
+        description: Insira o Client ID fornecido pelo Brandfetch
         label: Client ID
         placeholder: Insira seu Client ID aqui
-        title: Configurações do Brand Fetch
+        title: Configurações do Brandfetch
       openai_settings:
         description: Insira o token de acesso e configure opcionalmente um provedor compatível com OpenAI personalizado
         env_configured_message: Configurado com sucesso através de variáveis de ambiente.

--- a/config/locales/views/settings/hostings/pt-PT.yml
+++ b/config/locales/views/settings/hostings/pt-PT.yml
@@ -85,15 +85,15 @@ pt-PT:
           title: Desligar assistente externo?
           body: Isto removerá o URL, o token e o ID do agente guardados, e mudará para o assistente incorporado. Pode voltar a ligar-se mais tarde introduzindo novas credenciais.
       brand_fetch_settings:
-        description: Introduza o Client ID fornecido pela Brand Fetch
-        env_configured_message: Configurou com sucesso o seu Client ID da Brand Fetch através da variável de ambiente BRAND_FETCH_CLIENT_ID.
+        description: Introduza o Client ID fornecido pela Brandfetch
+        env_configured_message: Configurou com sucesso o seu Client ID da Brandfetch através da variável de ambiente BRAND_FETCH_CLIENT_ID.
         show_details: "(mostrar detalhes)"
-        setup_step_1_html: 'Visite <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> e crie uma conta gratuita de Developer da Brand Fetch.'
+        setup_step_1_html: 'Visite <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> e crie uma conta gratuita de Developer da Brandfetch.'
         setup_step_2_html: 'Vá para a página <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.'
         setup_step_3: 'Toque no ícone de olho na secção "Your Client ID" para revelar o seu Client ID e cole-o abaixo.'
         label: Client ID
         placeholder: Introduza o seu Client ID aqui
-        title: Definições da Brand Fetch
+        title: Definições da Brandfetch
         high_res_label: Ativar logótipos de alta resolução
         high_res_description: Quando ativado, os logótipos serão obtidos com resolução de 120x120 em vez de 40x40. Isto fornece imagens mais nítidas em ecrãs high-DPI.
       llm_provider_selector:

--- a/config/locales/views/settings/hostings/ro.yml
+++ b/config/locales/views/settings/hostings/ro.yml
@@ -25,10 +25,10 @@ ro:
           title: Ștergi cache-ul de date?
           body: Ești sigur că vrei să ștergi cache-ul de date? Aceasta va elimina toate ratele de schimb, prețurile titlurilor de valoare, soldurile conturilor și alte date. Această acțiune nu poate fi anulată.
       brand_fetch_settings:
-        description: Introdu ID-ul Clientului furnizat de Brand Fetch
+        description: Introdu ID-ul Clientului furnizat de Brandfetch
         label: ID Client
         placeholder: Introdu ID-ul tău de Client aici
-        title: Setări Brand Fetch
+        title: Setări Brandfetch
       openai_settings:
         description: Introdu tokenul de acces și configurează opțional un furnizor personalizat compatibil cu OpenAI
         env_configured_message: Configurat cu succes prin variabile de mediu.

--- a/config/locales/views/settings/hostings/ru.yml
+++ b/config/locales/views/settings/hostings/ru.yml
@@ -70,8 +70,8 @@ ru:
         url_label: URL конечной точки
         url_placeholder: https://your-agent-host/v1/chat
       brand_fetch_settings:
-        description: Введите Client ID, предоставленный Brand Fetch
-        env_configured_message: Вы успешно настроили ваш Brand Fetch Client ID через
+        description: Введите Client ID, предоставленный Brandfetch
+        env_configured_message: Вы успешно настроили ваш Brandfetch Client ID через
           переменную окружения BRAND_FETCH_CLIENT_ID.
         high_res_description: Если включено, логотипы будут получены в разрешении
           120x120 вместо 40x40. Это обеспечивает более четкие изображения на дисплеях
@@ -81,13 +81,13 @@ ru:
         placeholder: Введите ваш Client ID здесь
         setup_step_1_html: Посетите <a href="https://brandfetch.com/developers" target="_blank"
           rel="noopener noreferrer" class="underline">brandfetch.com</a> и создайте
-          бесплатный аккаунт разработчика Brand Fetch.
+          бесплатный аккаунт разработчика Brandfetch.
         setup_step_2_html: Перейдите на страницу <a href="https://developers.brandfetch.com/dashboard/logo-api"
           target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.
         setup_step_3: Нажмите на значок глаза в разделе "Ваш Client ID", чтобы показать
           ваш Client ID и вставьте его ниже.
         show_details: "(показать детали)"
-        title: Настройки Brand Fetch
+        title: Настройки Brandfetch
       clear_cache:
         cache_cleared: Кэш данных очищен. Это может занять несколько минут.
       disconnect_external_assistant:

--- a/config/locales/views/settings/hostings/tr.yml
+++ b/config/locales/views/settings/hostings/tr.yml
@@ -71,8 +71,8 @@ tr:
         url_label: Uç Nokta URL'si
         url_placeholder: https://your-agent-host/v1/chat
       brand_fetch_settings:
-        description: Brand Fetch tarafından sağlanan İstemci Kimliğini girin
-        env_configured_message: Brand Fetch İstemci Kimliğinizi BRAND_FETCH_CLIENT_ID
+        description: Brandfetch tarafından sağlanan İstemci Kimliğini girin
+        env_configured_message: Brandfetch İstemci Kimliğinizi BRAND_FETCH_CLIENT_ID
           ortam değişkeni aracılığıyla başarıyla yapılandırdınız.
         high_res_description: Etkinleştirildiğinde, logolar 40x40 yerine 120x120 çözünürlükte
           alınır. Bu, yüksek DPI'lı ekranlarda daha net görüntüler sağlar.
@@ -81,14 +81,14 @@ tr:
         placeholder: İstemci Kimliğinizi buraya girin
         setup_step_1_html: <a href="https://brandfetch.com/developers" target="_blank"
           rel="noopener noreferrer" class="underline">brandfetch.com</a> adresini
-          ziyaret edin ve ücretsiz bir Brand Fetch Geliştirici hesabı oluşturun.
+          ziyaret edin ve ücretsiz bir Brandfetch Geliştirici hesabı oluşturun.
         setup_step_2_html: <a href="https://developers.brandfetch.com/dashboard/logo-api"
           target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>
           sayfasına gidin.
         setup_step_3: İstemci Kimliğinizi göstermek için "İstemci Kimliğiniz" bölümündeki
           göz simgesine dokunun ve aşağıya yapıştırın.
         show_details: "(detayları göster)"
-        title: Brand Fetch Ayarları
+        title: Brandfetch Ayarları
       clear_cache:
         cache_cleared: Veri önbelleği temizlendi. Bu işlemin tamamlanması birkaç dakika
           sürebilir.

--- a/config/locales/views/settings/hostings/uk.yml
+++ b/config/locales/views/settings/hostings/uk.yml
@@ -82,15 +82,15 @@ uk:
           title: Відключити зовнішнього помічника?
           body: Це видалить збережену URL-адресу, токен та ID агента та переключиться на вбудованого помічника. Ви можете перепідключитися пізніше, ввівши нові облікові дані.
       brand_fetch_settings:
-        description: Введіть ідентифікатор клієнта, наданий Brand Fetch
-        env_configured_message: Ви успішно налаштували свій ідентифікатор клієнта Brand Fetch за допомогою змінної середовища BRAND_FETCH_CLIENT_ID.
+        description: Введіть ідентифікатор клієнта, наданий Brandfetch
+        env_configured_message: Ви успішно налаштували свій ідентифікатор клієнта Brandfetch за допомогою змінної середовища BRAND_FETCH_CLIENT_ID.
         show_details: "(показати деталі)"
-        setup_step_1_html: 'Відвідайте <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> і створіть безкоштовний обліковий запис розробника Brand Fetch.'
+        setup_step_1_html: 'Відвідайте <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> і створіть безкоштовний обліковий запис розробника Brandfetch.'
         setup_step_2_html: 'Перейдіть на сторінку <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.'
         setup_step_3: 'Торкніться значка ока в розділі "Ваш ідентифікатор клієнта", щоб відкрити свій ідентифікатор клієнта, і вставте його нижче.'
         label: Ідентифікатор клієнта
         placeholder: Введіть свій ідентифікатор клієнта тут
-        title: Налаштування Brand Fetch
+        title: Налаштування Brandfetch
         high_res_label: Увімкнути логотипи з високою роздільною здатністю
         high_res_description: Коли ввімкнено, логотипи будуть отримуватися з роздільною здатністю 120x120 замість 40x40. Це забезпечує чіткіші зображення на дисплеях з високою щільністю пікселів.
       llm_provider_selector:

--- a/config/locales/views/settings/hostings/vi.yml
+++ b/config/locales/views/settings/hostings/vi.yml
@@ -80,15 +80,15 @@ vi:
           title: Ngắt kết nối trợ lý bên ngoài?
           body: Thao tác này sẽ xóa URL, token và ID tác nhân đã lưu, và chuyển về trợ lý tích hợp sẵn. Bạn có thể kết nối lại sau bằng cách nhập thông tin xác thực mới.
       brand_fetch_settings:
-        description: Nhập Client ID do Brand Fetch cung cấp
-        env_configured_message: Bạn đã cấu hình thành công Client ID Brand Fetch qua biến môi trường BRAND_FETCH_CLIENT_ID.
+        description: Nhập Client ID do Brandfetch cung cấp
+        env_configured_message: Bạn đã cấu hình thành công Client ID Brandfetch qua biến môi trường BRAND_FETCH_CLIENT_ID.
         show_details: "(hiển thị chi tiết)"
-        setup_step_1_html: 'Truy cập <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> và tạo tài khoản nhà phát triển Brand Fetch miễn phí.'
+        setup_step_1_html: 'Truy cập <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> và tạo tài khoản nhà phát triển Brandfetch miễn phí.'
         setup_step_2_html: 'Đi đến trang <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a>.'
         setup_step_3: 'Nhấn biểu tượng mắt dưới phần "Your Client ID" để hiển thị Client ID và dán vào bên dưới.'
         label: Client ID
         placeholder: Nhập Client ID của bạn vào đây
-        title: Cài đặt Brand Fetch
+        title: Cài đặt Brandfetch
         high_res_label: Bật logo độ phân giải cao
         high_res_description: Khi bật, logo sẽ được lấy ở độ phân giải 120x120 thay vì 40x40. Điều này cung cấp hình ảnh sắc nét hơn trên màn hình độ phân giải cao.
       openai_settings:

--- a/config/locales/views/settings/hostings/zh-CN.yml
+++ b/config/locales/views/settings/hostings/zh-CN.yml
@@ -3,10 +3,10 @@ zh-CN:
   settings:
     hostings:
       brand_fetch_settings:
-        description: 请输入 Brand Fetch 提供的 Client ID
+        description: 请输入 Brandfetch 提供的 Client ID
         label: Client ID
         placeholder: 在此输入您的 Client ID
-        title: Brand Fetch 设置
+        title: Brandfetch 设置
         env_configured_message: 已通过环境变量配置 Brandfetch。
         show_details: "（显示详情）"
         setup_step_1_html: 前往 Brandfetch 并创建 API Key。

--- a/config/locales/views/settings/hostings/zh-TW.yml
+++ b/config/locales/views/settings/hostings/zh-TW.yml
@@ -87,15 +87,15 @@ zh-TW:
           title: 要中斷外部助手嗎？
           body: 這會移除已儲存的網址、Token 與 Agent ID，並切換回內建助手。日後輸入新的憑證就能重新連線。
       brand_fetch_settings:
-        description: 輸入 Brand Fetch 提供的 Client ID
-        env_configured_message: 您已透過 BRAND_FETCH_CLIENT_ID 環境變數成功設定 Brand Fetch Client ID。
+        description: 輸入 Brandfetch 提供的 Client ID
+        env_configured_message: 您已透過 BRAND_FETCH_CLIENT_ID 環境變數成功設定 Brandfetch Client ID。
         show_details: （顯示詳細資訊）
-        setup_step_1_html: 前往 <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> 註冊一個免費的 Brand Fetch 開發者帳號。
+        setup_step_1_html: 前往 <a href="https://brandfetch.com/developers" target="_blank" rel="noopener noreferrer" class="underline">brandfetch.com</a> 註冊一個免費的 Brandfetch 開發者帳號。
         setup_step_2_html: 前往 <a href="https://developers.brandfetch.com/dashboard/logo-api" target="_blank" rel="noopener noreferrer" class="underline">Logo API</a> 頁面。
         setup_step_3: 點選「Your Client ID」區塊下方的眼睛圖示以顯示您的 Client ID，然後貼到下方。
         label: Client ID
         placeholder: 在此輸入您的 Client ID
-        title: Brand Fetch 設定
+        title: Brandfetch 設定
         high_res_label: 啟用高解析度標誌
         high_res_description: 啟用後，標誌會以 120x120 而非 40x40 的解析度取得，在高 DPI 螢幕上會更清晰。
       llm_provider_selector:

--- a/docs/hosting/logos.md
+++ b/docs/hosting/logos.md
@@ -1,6 +1,6 @@
 # Account, Merchant and Security Logos
 
-Sure has integration with the [Brand Fetch Logo Link](https://brandfetch.com/developers/logo-api) service to provide logos for accounts, merchants and securities.
+Sure has integration with the [Brandfetch Logo Link](https://brandfetch.com/developers/logo-api) service to provide logos for accounts, merchants and securities.
 Logos are currently matched in the following ways:
 
 - For accounts, Plaid integration for the account is required and matched via FQDN (fully qualified domain name) from the Plaid integration
@@ -10,11 +10,11 @@ Logos are currently matched in the following ways:
 > [!NOTE]
 > Currently ticker symbol matching cannot specify the exchange and since US exchanges are prioritized, securities from other exchanges might not have the right logo.
 
-## Enabling Brand Fetch Integration
+## Enabling Brandfetch Integration
 
-A Brand Fetch Client ID is required and to obtain a client ID, sign up for an account [here](https://brandfetch.com/developers/logo-api).
+A Brandfetch Client ID is required and to obtain a client ID, sign up for an account [here](https://brandfetch.com/developers/logo-api).
 
-Once you enter the Client ID into the Sure settings under the `Self-Hosting` section, logos from Brand Fetch integration will be enabled.
+Once you enter the Client ID into the Sure settings under the `Self-Hosting` section, logos from Brandfetch integration will be enabled.
 Alternatively, you can provide the client id using the `BRAND_FETCH_CLIENT_ID` environment variable to the web and worker services.
 
 ![CLIENT_ID screenshot](logos-clientid.png)


### PR DESCRIPTION
Several locales and the logo hosting guide spelled the service "Brand Fetch". The service is named Brandfetch. Updated all locations to use the correct spelling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated hosting settings translations across supported languages to consistently display the provider name as “Brandfetch.”
  - Revised logo hosting documentation to use the “Brandfetch” name consistently across service, integration, and client ID references.
  - Updated related setup instructions, configuration messages, descriptions, and section titles to reflect the standardized Brandfetch naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->