### PR TITLE
fix(l10n): localize German AI diagnostic failure reasons

### DIFF
--- a/config/locales/views/admin/system_health/de.yml
+++ b/config/locales/views/admin/system_health/de.yml
@@ -37,6 +37,23 @@ de:
           seconds: "%{seconds} s"
           no_queues: Es sind keine Warteschlangen registriert. Möglicherweise läuft der Worker nicht.
         ai:
+          labels:
+            failure_reason: Fehlerursache
+            function_calling_failure_reason: Fehlerursache beim Funktionsaufruf
+            pdf_text_extraction_failure_reason: Fehlerursache bei der Textextraktion
+            pdf_vision_processing_failure_reason: Fehlerursache bei der Bildverarbeitung oder nativen Dokumentverarbeitung
+          failure_codes:
+            model_not_available: Das konfigurierte Modell wurde vom Anbieter nicht zurückgegeben
+            no_tool_call: Das Modell hat geantwortet, ohne das Prüfwerkzeug aufzurufen
+            tools_refused: Der Dienst hat dieselbe Anfrage ohne Werkzeuge beantwortet, sie mit Werkzeugen jedoch abgelehnt
+            invalid_response: Der Dienst hat eine unerwartete Antwort zurückgegeben
+            dimensions_mismatch: Die Dimensionen des Embedding-Vektors stimmen nicht mit den konfigurierten Dimensionen überein
+            extension_not_enabled: Die PostgreSQL-Erweiterung vector ist nicht aktiviert
+            table_not_found: Die Tabelle vector_store_chunks wurde nicht gefunden
+            render_missing_binary: Der Renderer pdftoppm (poppler-utils) ist in diesem Container nicht verfügbar
+            timeout: Der Dienst hat nicht innerhalb des Zeitlimits für die Prüfung geantwortet
+            request_failed: Die Anfrage an den Dienst ist fehlgeschlagen
+            unsupported_provider: Der Anbieter unterstützt diese Prüfung nicht
           worker:
             title: Worker-Verifikation
             description: Die obigen Prüfungen wurden in diesem Web-Prozess ausgeführt. Die meisten KI-Aufgaben – Antworten des Assistenten, PDF-Verarbeitung, Embeddings, automatische Kategorisierung und Händlererkennung – laufen jedoch in einem Sidekiq-Worker-Prozess. Dessen Netzwerkzugriff, DNS, Proxy-Regeln oder geladene Zugangsdaten können abweichen. Stelle eine Prüfung in die Warteschlange, um die Konfiguration und Erreichbarkeit aus Sicht eines Workers zu prüfen.

--- a/test/controllers/admin/system_health_controller_test.rb
+++ b/test/controllers/admin/system_health_controller_test.rb
@@ -609,6 +609,46 @@ class Admin::SystemHealthControllerTest < ActionDispatch::IntegrationTest
     assert_match(/The configured model was not returned by the provider/, response.body)
   end
 
+  test "German AI failure reasons are present without fallback and render in worker results" do
+    reasons = {
+      model_not_available: "Das konfigurierte Modell wurde vom Anbieter nicht zurückgegeben",
+      no_tool_call: "Das Modell hat geantwortet, ohne das Prüfwerkzeug aufzurufen",
+      tools_refused: "Der Dienst hat dieselbe Anfrage ohne Werkzeuge beantwortet, sie mit Werkzeugen jedoch abgelehnt",
+      invalid_response: "Der Dienst hat eine unerwartete Antwort zurückgegeben",
+      dimensions_mismatch: "Die Dimensionen des Embedding-Vektors stimmen nicht mit den konfigurierten Dimensionen überein",
+      extension_not_enabled: "Die PostgreSQL-Erweiterung vector ist nicht aktiviert",
+      table_not_found: "Die Tabelle vector_store_chunks wurde nicht gefunden",
+      render_missing_binary: "Der Renderer pdftoppm (poppler-utils) ist in diesem Container nicht verfügbar",
+      timeout: "Der Dienst hat nicht innerhalb des Zeitlimits für die Prüfung geantwortet",
+      request_failed: "Die Anfrage an den Dienst ist fehlgeschlagen",
+      unsupported_provider: "Der Anbieter unterstützt diese Prüfung nicht"
+    }
+    reasons.each do |code, text|
+      assert_equal text, I18n.t("admin.system_health.show.ai.failure_codes.#{code}", locale: :de, fallback: false, raise: true)
+    end
+    {
+      failure_reason: "Fehlerursache",
+      function_calling_failure_reason: "Fehlerursache beim Funktionsaufruf",
+      pdf_text_extraction_failure_reason: "Fehlerursache bei der Textextraktion",
+      pdf_vision_processing_failure_reason: "Fehlerursache bei der Bildverarbeitung oder nativen Dokumentverarbeitung"
+    }.each do |key, text|
+      assert_equal text, I18n.t("admin.system_health.show.ai.labels.#{key}", locale: :de, fallback: false, raise: true)
+    end
+
+    sign_in users(:sure_support_staff)
+    stub_healthy_sidekiq
+    with_memory_cache do
+      with_ai_environment do
+        WorkerAiHealth.record!(worker_snapshot(llm_status: :failing, failure_codes: reasons.keys))
+        get admin_system_health_url(tab: "ai", locale: :de)
+      end
+    end
+
+    assert_response :success
+    assert_select "dt", text: "Fehlerursache"
+    reasons.each_value { |text| assert_select "dd", text: /#{Regexp.escape(text)}/ }
+  end
+
   test "AI status shows a stale worker result as stale rather than passing" do
     sign_in users(:sure_support_staff)
     stub_healthy_sidekiq


### PR DESCRIPTION
## Summary

AI diagnostic failure reasons now appear in German instead of falling back to English, including explanations for unavailable models, refused tool calls, embedding errors, and PDF renderer failures.

This continues the German system-health translations after worker verification. The broader status labels and remediation alerts remain separate work. English copy, diagnostic codes, authorization, and probe behavior are unchanged. A separate AI language review approved the wording; this is not a human language-review claim.

Related: #3509

## Validation

- Observed the missing German translation before adding the locale entries.
- Focused controller and locale tests: 42 runs, 571 assertions, no failures or errors; four existing skips.
- Full suite with `TZ=UTC`: 8,757 runs, 35,485 assertions, no failures or errors; 33 existing skips.
- Synthetic browser check: long failure reasons fit at widths 1024, 1440, and 500 without clipping; 1 run, 9 assertions passed.
- RuboCop, ERB lint, Biome, and Brakeman passed. Independent correctness, testing, and standards review found no issues.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: only German display text and regression coverage change; no probes, configuration, or background jobs change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Added German translations for AI system health failure labels and codes, including model availability, tool calls, response validation, vector storage, PDF rendering, timeouts, request failures, and unsupported providers.

- **Tests**
  - Added coverage verifying German translations display correctly without fallback on the system health page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->