### PR TITLE
feat(investments): add Cash Management Account subtype

### DIFF
--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -9,6 +9,7 @@ class Investment < ApplicationRecord
   SUBTYPES = {
     # === United States ===
     "brokerage" => { short: "Brokerage", long: "Brokerage", region: "us", tax_treatment: :taxable },
+    "cash_management" => { short: "CMA", long: "Cash Management Account", region: "us", tax_treatment: :taxable },
     "401k" => { short: "401(k)", long: "401(k)", region: "us", tax_treatment: :tax_deferred },
     "roth_401k" => { short: "Roth 401(k)", long: "Roth 401(k)", region: "us", tax_treatment: :tax_exempt },
     "403b" => { short: "403(b)", long: "403(b)", region: "us", tax_treatment: :tax_deferred },

--- a/config/locales/views/investments/en.yml
+++ b/config/locales/views/investments/en.yml
@@ -15,6 +15,9 @@ en:
       brokerage:
         short: Brokerage
         long: Brokerage
+      cash_management:
+        short: CMA
+        long: Cash Management Account
       401k:
         short: 401(k)
         long: 401(k)

--- a/test/models/investment_test.rb
+++ b/test/models/investment_test.rb
@@ -25,7 +25,7 @@ class InvestmentTest < ActiveSupport::TestCase
   end
 
   test "tax_treatment returns taxable for standard accounts" do
-    %w[brokerage mutual_fund angel trust ugma utma other].each do |subtype|
+    %w[brokerage cash_management mutual_fund angel trust ugma utma other].each do |subtype|
       investment = Investment.new(subtype: subtype)
       assert_equal :taxable, investment.tax_treatment, "Expected #{subtype} to be taxable"
     end


### PR DESCRIPTION
## Problem

Brokerage-held cash accounts, such as Fidelity's Cash Management Account (CMA), are legally brokerage accounts. SnapTrade reports them with `account_category: INVESTMENT`, so Sure links them as Investment accounts. SnapTrade doesn't set a subtype, and none of the existing Investment subtypes describe a CMA, so users have to pick the closest option, "Brokerage".

## Change

Adds a `cash_management` Investment subtype:

- `Investment::SUBTYPES`: `short: "CMA"`, `long: "Cash Management Account"`, `region: "us"`, `tax_treatment: :taxable`
- English labels in `config/locales/views/investments/en.yml` (other locales fall back to English)
- Added to the taxable-subtypes assertion in `test/models/investment_test.rb`

## Resulting behavior

The subtype only changes the label. It appears in the US group of the Investment subtype dropdown and shows as "Cash Management Account" / "CMA" on the account. Its tax treatment is `:taxable`, the same as `brokerage`, so the tax badge, gains-by-tax-treatment report and budget/cashflow exclusions behave exactly as they do for a brokerage account. There's no migration, and existing accounts aren't changed.

Other label-only `:taxable` subtypes like this already exist (`mutual_fund`, `angel`, `trust`, `gold`).

## Validation

- `bin/rails test test/models/investment_test.rb test/i18n_test.rb test/models/plaid_account/type_mappable_test.rb`: passing
- `bin/rubocop -f github -a`: no offenses
- `bundle exec erb_lint ./app/**/*.erb -a`: no errors
- `bin/brakeman --no-pager`: 0 warnings
- Full `bin/rails test`: 87 failures and 4 errors in my local environment. **The same 87 failures and 4 errors happen on `main` without this change.** They're in passkeys, MFA, AI chat, subscriptions, rate limiting and hosting settings, and none involve investments. I believe they come from my local environment config. CI should confirm.
- `npm run lint` (Biome): not run locally because `node_modules` isn't installed. This PR has no JavaScript changes.
- System tests: not run; no UI flow changes.

No screenshot is included; the only UI change is one new option in the existing subtype dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cash Management Accounts (CMA) as an investment subtype.
  * CMAs are labeled “CMA” and “Cash Management Account” and treated as taxable investments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->