### PR TITLE
fix(insights): narrate LLM insight bodies in the family's locale

### DIFF
--- a/app/models/insight/body_writer.rb
+++ b/app/models/insight/body_writer.rb
@@ -31,7 +31,7 @@ class Insight::BodyWriter
     # fallback already follows I18n, so this keeps both paths in the same language.
     def language_instruction
       locale = family.locale.presence || I18n.default_locale.to_s
-      "- Write in the user's language (ISO 639-1 code: #{locale}).\n"
+      "- Write in the user's language (BCP 47 locale: #{locale}).\n"
     end
 
     def template_body(generated_insight)

--- a/app/models/insight/body_writer.rb
+++ b/app/models/insight/body_writer.rb
@@ -26,6 +26,14 @@ class Insight::BodyWriter
   private
     attr_reader :family
 
+    # The system prompt is written in English, so without an explicit instruction the
+    # model narrates in English even when the family uses another locale. The template
+    # fallback already follows I18n, so this keeps both paths in the same language.
+    def language_instruction
+      locale = family.locale.presence || I18n.default_locale.to_s
+      "- Write in the user's language (ISO 639-1 code: #{locale}).\n"
+    end
+
     def template_body(generated_insight)
       I18n.t(
         "insights.templates.#{generated_insight.template_key}",
@@ -44,7 +52,7 @@ class Insight::BodyWriter
       response = provider.chat_response(
         prompt,
         model: provider.class.effective_model,
-        instructions: SYSTEM_PROMPT,
+        instructions: SYSTEM_PROMPT + language_instruction,
         family: family
       )
       return nil unless response.success?

--- a/test/models/insight/body_writer_test.rb
+++ b/test/models/insight/body_writer_test.rb
@@ -23,6 +23,19 @@ class Insight::BodyWriterTest < ActiveSupport::TestCase
     assert_equal "Narrated body.", body
   end
 
+  test "tells the LLM to write in the family's locale" do
+    @family.update!(locale: "pl")
+    provider = FakeLlmProvider.new("Narrated body.")
+    captured = nil
+    provider.stubs(:chat_response).with { |*, **kwargs| captured = kwargs[:instructions]; true }
+      .returns(OpenStruct.new(success?: true, data: OpenStruct.new(messages: [ OpenStruct.new(id: "1", output_text: "Narrated body.") ])))
+    Provider::Registry.stubs(:preferred_llm_provider).returns(provider)
+
+    Insight::BodyWriter.new(@family).write(generated_insight)
+
+    assert_includes captured, "ISO 639-1 code: pl"
+  end
+
   test "falls back to the template and captures a debug log when the LLM call fails" do
     provider = FakeLlmProvider.new("unused")
     provider.stubs(:chat_response).raises(StandardError.new("boom"))

--- a/test/models/insight/body_writer_test.rb
+++ b/test/models/insight/body_writer_test.rb
@@ -23,8 +23,8 @@ class Insight::BodyWriterTest < ActiveSupport::TestCase
     assert_equal "Narrated body.", body
   end
 
-  test "tells the LLM to write in the family's locale" do
-    @family.update!(locale: "pl")
+  test "tells the LLM to write in the family's full locale tag" do
+    @family.update!(locale: "pt-BR")
     provider = FakeLlmProvider.new("Narrated body.")
     captured = nil
     provider.stubs(:chat_response).with { |*, **kwargs| captured = kwargs[:instructions]; true }
@@ -33,7 +33,7 @@ class Insight::BodyWriterTest < ActiveSupport::TestCase
 
     Insight::BodyWriter.new(@family).write(generated_insight)
 
-    assert_includes captured, "ISO 639-1 code: pl"
+    assert_includes captured, "BCP 47 locale: pt-BR"
   end
 
   test "falls back to the template and captures a debug log when the LLM call fails" do


### PR DESCRIPTION
With an LLM provider configured, `Insight::BodyWriter` narrates insight bodies from an English-only system prompt, so a family using another locale gets Polish titles (from i18n) but English prose. The template fallback already follows I18n.

This appends the family's locale to the instructions (`Write in the user's language (ISO 639-1 code: pl)`), so both paths produce the same language. Verified on a Polish self-hosted instance: after the change, regenerated insights come back in Polish. Unit test added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI-generated insight narration now follows the family’s configured language and regional variant when supported.

- **Bug Fixes**
  - Improved consistency between the selected locale and provider-generated insight text, including full locale tags such as `pt-BR`.

- **Tests**
  - Added coverage verifying that language and regional locale information is communicated to the narration provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->