### PR TITLE
Treat consented Plaid products as supported

### DIFF
--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -198,10 +198,22 @@ class PlaidItem < ApplicationRecord
       end
     end
 
-    # Plaid returns mutually exclusive arrays here.  If the item has made a request for a product,
-    # it is put in the billed_products array.  If it is supported, but not yet used, it goes in the
-    # available_products array.
+    # Plaid splits an item's products across three arrays. If the item has made a
+    # request for a product, it is put in the billed_products array. If it is
+    # supported but not yet used, it goes in available_products. Products granted
+    # through Link's `additional_consented_products` appear in neither -- they are
+    # reported in consented_products until the first call actually bills them.
+    #
+    # That third array matters because it is how we request `transactions` for
+    # liability accounts: Provider::Plaid#get_primary_product returns "liabilities"
+    # for CreditCard/Loan, so `transactions` can only arrive as an additionally
+    # consented product. Omitting it made supports_product?("transactions") false
+    # for every Plaid-linked credit card, so PlaidItem::AccountsSnapshot skipped
+    # the transactions fetch entirely and those accounts imported balances and
+    # liabilities but no transactions at all.
     def supported_products
-      available_products + billed_products
+      consented = raw_payload.is_a?(Hash) ? Array(raw_payload["consented_products"]) : []
+
+      (available_products + billed_products + consented).map(&:to_s).uniq
     end
 end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -9,6 +9,34 @@ class PlaidItemTest < ActiveSupport::TestCase
     Provider::Registry.stubs(:plaid_provider_for_region).returns(@plaid_provider)
   end
 
+  test "supports products granted through additional_consented_products" do
+    # Plaid reports products consented to at Link time -- but not yet billed --
+    # in consented_products, which is neither available_products nor
+    # billed_products. A credit-card item looks exactly like this: `liabilities`
+    # is billed, while `transactions` is only consented.
+    @plaid_item.update!(
+      available_products: [ "balance" ],
+      billed_products: [ "liabilities" ],
+      raw_payload: { "consented_products" => [ "transactions", "liabilities", "investments" ] }
+    )
+
+    assert @plaid_item.supports_product?("transactions")
+    assert @plaid_item.supports_product?("liabilities")
+    assert @plaid_item.supports_product?("balance")
+    assert_not @plaid_item.supports_product?("assets")
+  end
+
+  test "supported products tolerate a missing or non-hash raw payload" do
+    @plaid_item.update!(
+      available_products: [ "balance" ],
+      billed_products: [ "transactions" ],
+      raw_payload: nil
+    )
+
+    assert @plaid_item.supports_product?("transactions")
+    assert_not @plaid_item.supports_product?("liabilities")
+  end
+
   test "removes plaid item when destroyed" do
     @plaid_provider.expects(:remove_item).with(@plaid_item.access_token).once
 


### PR DESCRIPTION
## Problem

A credit card linked through Plaid imports its balance and liabilities but **zero transactions**.

`PlaidItem#supported_products` reads two of the three product arrays Plaid returns:

```ruby
def supported_products
  available_products + billed_products
end
```

Products granted through Link's `additional_consented_products` are reported in a third array, `consented_products`, and stay there until a call actually bills them. They appear in neither of the two arrays above.

That third array is the only path by which `transactions` reaches a liability item. `Provider::Plaid#get_primary_product` returns `"liabilities"` for `CreditCard` and `Loan`, so `transactions` can only arrive via `get_additional_consented_products`:

```ruby
def get_additional_consented_products(accountable_type)
  return [] if eu?

  case get_primary_product(accountable_type)
  when "liabilities"
    SUPPORTED_PLAID_PRODUCTS - [ "liabilities" ]
  ...
```

So `supports_product?("transactions")` was false for every Plaid-linked credit card. `PlaidItem::AccountsSnapshot#can_fetch_transactions?` gates on it, so the transactions fetch was skipped outright and the account imported balances and liabilities with nothing else.

## Reproduction

Against a production Citi item (`ins_5`), `/item/get` returns:

```
billed_products:    ["liabilities"]
available_products: ["balance"]
consented_products: ["assets", "identity", "identity_match", "investments",
                     "liabilities", "signal", "transactions"]
```

`supports_product?("transactions")` → `false`, and the linked account held only an opening balance valuation.

## Fix

Include `consented_products` in `supported_products`. `upsert_plaid_snapshot!` already persists the full item snapshot to `raw_payload`, so the data is present and no migration is needed.

After the change the same item synced **147 transactions**.

## Notes for reviewers

- The first `/transactions/sync` call on an item that has never used the product returns an empty `added` list: that call initialises the product and starts Plaid's asynchronous historical pull, and the data lands a few minutes later. Worth knowing when verifying this by hand, since it looks at first like the fix did nothing.
- `raw_payload` is guarded with `is_a?(Hash)` so items snapshotted before this change, or fixtures with a nil payload, keep working.
- Two regression tests added to `test/models/plaid_item_test.rb`.

## Related

Same area as #3531, which fixes a narrow subtype check that stopped liabilities being fetched for `credit/paypal` accounts. Independent of it; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Product support detection now includes products granted through consent, in addition to available and billed products.
  - Product checks remain reliable when raw account data is missing or malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->